### PR TITLE
Add Google AppEngine plugin to Maven POM.

### DIFF
--- a/WCP-WS/pom.xml
+++ b/WCP-WS/pom.xml
@@ -239,6 +239,11 @@
 					<target>1.7</target>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>com.google.appengine</groupId>
+				<artifactId>appengine-maven-plugin</artifactId>
+				<version>1.9.79</version>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
Following instructions at https://cloud.google.com/appengine/docs/standard/java/tools/maven#using_maven