### PR TITLE
Add google copyright to license.txt

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
-Copyright © 2017-2019 Harvard Pilgrim Health Care Institute (HPHCI) and its
-Contributors. 
-Copyright 2020 Google LLC
+Copyright © 2017-2019 Harvard Pilgrim Health Care Institute (HPHCI) and its Contributors.
+ 
+Copyright 2020 Google LLC.
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation files (the


### PR DESCRIPTION
Updates the main license.

I am not sure if we should add separate Google only license files in the new components that were added for early-access.