### PR TITLE
Add roles/cloudsql.client binding for the data project

### DIFF
--- a/Terraform/org/folder.fda-my-studies/project.heroes-hat-dev-apps/apps/outputs.tf
+++ b/Terraform/org/folder.fda-my-studies/project.heroes-hat-dev-apps/apps/outputs.tf
@@ -1,0 +1,3 @@
+output "service_account" {
+  value = module.heroes_hat_cluster.service_account
+}

--- a/Terraform/org/folder.fda-my-studies/project.heroes-hat-dev-data/iam/main.tf
+++ b/Terraform/org/folder.fda-my-studies/project.heroes-hat-dev-data/iam/main.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "gcs" {}
+}
+
+resource "google_project_iam_member" "gke_sql_access" {
+  project = var.project_id
+  role    = "roles/cloudsql.client"
+  member  = var.gke_service_account
+}

--- a/Terraform/org/folder.fda-my-studies/project.heroes-hat-dev-data/iam/terraform.tfvars
+++ b/Terraform/org/folder.fda-my-studies/project.heroes-hat-dev-data/iam/terraform.tfvars
@@ -1,0 +1,1 @@
+project_id = "heroes-hat-dev-data"

--- a/Terraform/org/folder.fda-my-studies/project.heroes-hat-dev-data/iam/terragrunt.hcl
+++ b/Terraform/org/folder.fda-my-studies/project.heroes-hat-dev-data/iam/terragrunt.hcl
@@ -1,0 +1,20 @@
+include {
+  path = find_in_parent_folders()
+}
+
+dependency "project" {
+  config_path  = "../project"
+  skip_outputs = true
+}
+
+dependency "apps" {
+  config_path = "../../project.heroes-hat-dev-apps/apps"
+
+  mock_outputs = {
+    service_account = "mock-service-account"
+  }
+}
+
+inputs = {
+  gke_service_account = dependency.apps.outputs.service_account
+}

--- a/Terraform/org/folder.fda-my-studies/project.heroes-hat-dev-data/iam/variables.tf
+++ b/Terraform/org/folder.fda-my-studies/project.heroes-hat-dev-data/iam/variables.tf
@@ -1,0 +1,9 @@
+variable "project_id" {
+  type = string
+}
+
+variable "gke_service_account" {
+  description = "The service account used by the GKE cluster"
+  type        = string
+}
+


### PR DESCRIPTION
Requires a new module under data/ because:
* apps depends on data to exist for the Cloud SQL connection
* This new IAM binding in data requires apps to exist to know the service account