### PR TITLE
Create a static external IP for the Ingress

### DIFF
--- a/Terraform/org/folder.fda-my-studies/project.heroes-hat-dev-apps/apps/main.tf
+++ b/Terraform/org/folder.fda-my-studies/project.heroes-hat-dev-apps/apps/main.tf
@@ -64,3 +64,12 @@ resource "google_service_account" "apps_service_accounts" {
   description = "Terraform-generated service account for use by the ${each.key} GKE app"
   project     = var.project_id
 }
+
+# Reserve a static external IP for the Ingress.
+resource "google_compute_address" "ingress_static_ip" {
+  name         = "my-studies-ingress-ip"
+  description  = "Reserved static external IP for the GKE cluster Ingress and DNS configurations."
+  address_type = "EXTERNAL" # This is the default, but be explicit because it's important.
+  region       = var.gke_region
+  project      = var.project_id
+}

--- a/kubernetes/ingress.yaml
+++ b/kubernetes/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: heroes-hat-dev
   annotations:
-    kubernetes.io/ingress.global-static-ip-name: heroes-hat
+    kubernetes.io/ingress.global-static-ip-name: my-studies-ingress-ip
     networking.gke.io/managed-certificates: heroes-hat-cert
 spec:
   rules:


### PR DESCRIPTION
GKE can create an external IP automatically, but it may change if the ingress is deleted and recreated. Instead, create one in Terraform, and always use the same one in the Ingress.