### PR TITLE
Change Ingress static IP to global

### DIFF
--- a/Terraform/org/folder.fda-my-studies/project.heroes-hat-dev-apps/apps/main.tf
+++ b/Terraform/org/folder.fda-my-studies/project.heroes-hat-dev-apps/apps/main.tf
@@ -66,10 +66,9 @@ resource "google_service_account" "apps_service_accounts" {
 }
 
 # Reserve a static external IP for the Ingress.
-resource "google_compute_address" "ingress_static_ip" {
+resource "google_compute_global_address" "ingress_static_ip" {
   name         = "my-studies-ingress-ip"
   description  = "Reserved static external IP for the GKE cluster Ingress and DNS configurations."
   address_type = "EXTERNAL" # This is the default, but be explicit because it's important.
-  region       = var.gke_region
   project      = var.project_id
 }


### PR DESCRIPTION
Looking again at the instructions at https://cloud.google.com/kubernetes-engine/docs/tutorials/configuring-domain-name-static-ip, this address should be global.