### PR TITLE
Add Istio prometheus images to BinAuthZ

### DIFF
--- a/Terraform/org/folder.fda-my-studies/project.heroes-hat-dev-apps/apps/main.tf
+++ b/Terraform/org/folder.fda-my-studies/project.heroes-hat-dev-apps/apps/main.tf
@@ -84,13 +84,13 @@ resource "google_binary_authorization_policy" "policy" {
   project = var.project_id
 
   # Whitelist images from this project.
-  # See https://cloud.google.com/binary-authorization/docs/policy-yaml-reference#admissionwhitelistpatterns
   admission_whitelist_patterns {
     name_pattern = "gcr.io/${var.project_id}/*"
   }
   admission_whitelist_patterns {
     name_pattern = "gcr.io/cloudsql-docker/*"
   }
+
   # Not all istio images are added by default in the "google images" policy.
   admission_whitelist_patterns {
     name_pattern = "gke.gcr.io/istio/*"
@@ -99,6 +99,24 @@ resource "google_binary_authorization_policy" "policy" {
     # The more generic pattern above does not seem to be enough for all images.
     name_pattern = "gke.gcr.io/istio/prometheus/*"
   }
+
+  # Recommendations from https://cloud.google.com/binary-authorization/docs/policy-yaml-reference#admissionwhitelistpatterns
+  admission_whitelist_patterns {
+    name_pattern = "gcr.io/google_containers/*"
+  }
+  admission_whitelist_patterns {
+    name_pattern = "gcr.io/google-containers/*"
+  }
+  admission_whitelist_patterns {
+    name_pattern = "k8s.gcr.io/*"
+  }
+  admission_whitelist_patterns {
+    name_pattern = "gke.gcr.io/*"
+  }
+  admission_whitelist_patterns {
+    name_pattern = "gcr.io/stackdriver-agents/*"
+  }
+
 
   # Allow Google-built images.
   # See https://cloud.google.com/binary-authorization/docs/policy-yaml-reference#globalpolicyevaluationmode


### PR DESCRIPTION
It seems like the more generic pattern is not enough for all Istio images.