### PR TITLE
Pin the sql module to 3.1.0, since 3.2.0 broke CICD

### DIFF
--- a/Terraform/org/folder.fda-my-studies/project.heroes-hat-dev-data/data/main.tf
+++ b/Terraform/org/folder.fda-my-studies/project.heroes-hat-dev-data/data/main.tf
@@ -42,7 +42,7 @@ data "google_secret_manager_secret_version" "sql_password" {
 
 module "my_studies_cloudsql" {
   source  = "GoogleCloudPlatform/sql-db/google//modules/safer_mysql"
-  version = "~> 3.0"
+  version = "~> 3.1.0"
 
   name             = "my-studies-2"
   project_id       = var.project_id


### PR DESCRIPTION
See https://pantheon.corp.google.com/cloud-build/builds/4c5718ac-9a9b-486d-8d67-3df5069ab2e7?project=heroes-hat-dev-devops:
```
Step #3: Error: Error, failed to update instance settings for : googleapi: Error 400: The incoming request contained invalid data., invalidRequest
Step #3:
Step #3:   on .terraform/modules/my_studies_cloudsql/terraform-google-sql-db-3.2.0/modules/mysql/main.tf line 31, in resource "google_sql_database_instance" "default":
Step #3:   31: resource "google_sql_database_instance" "default" {
```

This works with 3.1.0, but breaks on 3.2.0