### PR TITLE
Explict add __name__ field in firestore index.

### DIFF
--- a/Terraform/org/folder.fda-my-studies/project.heroes-hat-dev-resp-firebase/firebase/main.tf
+++ b/Terraform/org/folder.fda-my-studies/project.heroes-hat-dev-resp-firebase/firebase/main.tf
@@ -40,6 +40,10 @@ resource "google_firestore_index" "activities_index" {
     field_path = "createdTimestamp"
     order      = "ASCENDING"
   }
+  fields {
+    field_path = "__name__"
+    order      = "ASCENDING"
+  }
 }
 
 module "survey_pubsub" {


### PR DESCRIPTION
\_\_name\_\_ field is implicitly added
(https://www.terraform.io/docs/providers/google/r/firestore_index.html)
and if not specified in the config, terraform apply will attempt to
recreate the index every time.

Example of recreation attempt if \_\_name\_\_ is not explicitly specified: https://console.cloud.google.com/cloud-build/builds/796baee0-9d30-4c8f-bb6f-27e86d41e983;step=4?project=heroes-hat-dev-devops