### PR TITLE
Linter perf improvements

### DIFF
--- a/UR-web-app/.eslintrc.js
+++ b/UR-web-app/.eslintrc.js
@@ -19,12 +19,7 @@ module.exports = {
     ecmaVersion: 11,
     sourceType: 'module',
     tsconfigRootDir: __dirname,
-    project: [
-      './src/tsconfig.app.json',
-      './src/tsconfig.spec.json',
-      './e2e/tsconfig.e2e.json',
-      'tsconfig.eslint.json',
-    ],
+    project: 'tsconfig.eslint.json',
   },
   plugins: ['@typescript-eslint'],
   rules: {

--- a/UR-web-app/e2e/.eslintrc.yml
+++ b/UR-web-app/e2e/.eslintrc.yml
@@ -1,0 +1,6 @@
+extends: ["../.eslintrc.js"]
+parserOptions:
+  ecmaVersion: 11
+  sourceType: "module"
+  tsconfigRootDir: "e2e"
+  project: "tsconfig.e2e.json"

--- a/UR-web-app/e2e/tsconfig.e2e.json
+++ b/UR-web-app/e2e/tsconfig.e2e.json
@@ -5,5 +5,6 @@
     "module": "commonjs",
     "target": "es5",
     "types": ["jasmine", "jasminewd2", "node"]
-  }
+  },
+  "include": ["**/*.ts", "**/*.js", "*.js"]
 }

--- a/UR-web-app/tsconfig.eslint.json
+++ b/UR-web-app/tsconfig.eslint.json
@@ -1,9 +1,11 @@
 {
   "extends": "./tsconfig.json",
   "include": [
-    "src/karma.conf.js",
-    "e2e/protractor.conf.js",
+    "src/**/*.js",
+    "src/**/*.ts",
     ".eslintrc.js",
-    "src/environments/*"
-  ]
+  ],
+  "compilerOptions": {
+    "types": ["jasmine", "node"]
+  },
 }


### PR DESCRIPTION
ESLint doesn't like when you define a lot of projects. By only using the special "tsconfig.eslint.json" performance increases significantly. A second eslint config file is used to differentiate the types in jasminewd2 and jasmine.