### PR TITLE
Auth server database version mismatch issue fix ( early-access branch)

### DIFF
--- a/auth-server-ws/auth_server_db_script.sql
+++ b/auth-server-ws/auth_server_db_script.sql
@@ -95,6 +95,8 @@ CREATE TABLE IF NOT EXISTS `users` (
   `temp_password_date` datetime DEFAULT NULL,
   `user_id` varchar(255) DEFAULT NULL,
   `password_expire_date` datetime DEFAULT NULL,
+  `locked_account_temp_pwd` varchar(255) DEFAULT NULL,
+  `locked_account_temp_pwd_expire_date` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 

--- a/auth-server-ws/src/main/resources/application.properties
+++ b/auth-server-ws/src/main/resources/application.properties
@@ -23,7 +23,7 @@ spring.datasource.hikari.maxLifetime=1800000
 spring.datasource.driver-class-name=com.mysql.jdbc.Driver
 spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.MySQL55Dialect
 spring.jpa.hibernate.naming.strategy=org.hibernate.cfg.ImprovedNamingStrategy
-spring.jpa.hibernate.ddl-auto = none
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 
 # EMBEDDED SERVER CONFIGURATION


### PR DESCRIPTION
This PR contains below list of changes to resolve the auth server database version mismatch issue fix #585 .

1. changed **spring.jpa.hibernate.ddl-auto** property to **update**.
2. added **locked_account_temp_pwd** and **locked_account_temp_pwd_expire_date** columns to main db script.