### PR TITLE
iOS - Remove progress loader for refresh token after idle time. (Duplicate)

### DIFF
--- a/iOS/HPHC/HPHC/Controllers/StudyUI/ActivityUI/ActivitiesViewController.swift
+++ b/iOS/HPHC/HPHC/Controllers/StudyUI/ActivityUI/ActivitiesViewController.swift
@@ -1145,6 +1145,8 @@ extension ActivitiesViewController: NMWebServiceDelegate {
       DBHandler.updateMetaDataToUpdateForStudy(study: Study.currentStudy!, updateDetails: nil)
 
       self.checkForActivitiesUpdates()
+    } else if requestName as String == AuthServerMethods.getRefreshedToken.method.methodName {
+      self.removeProgressIndicator()
     }
   }
 


### PR DESCRIPTION
cherry-picked from #601

