### PR TITLE
Fixed issue #864 forgot password-return error code if account not yet verified

### DIFF
--- a/common-modules/common-service/src/main/java/com/google/cloud/healthcare/fdamystudies/common/ErrorCode.java
+++ b/common-modules/common-service/src/main/java/com/google/cloud/healthcare/fdamystudies/common/ErrorCode.java
@@ -61,6 +61,12 @@ public enum ErrorCode {
       Constants.BAD_REQUEST,
       "Your account has not been activated yet. Account need to be activated by an activation link that arrives via email to the address you provided."),
 
+  ACCOUNT_NOT_VERIFIED(
+      403,
+      "EC-117",
+      Constants.BAD_REQUEST,
+      "Your account is not verified. Please verify your account by clicking on the link which has been sent to your registered email. if not received, would you like to resend verification link?"),
+
   CURRENT_PASSWORD_INVALID(400, "EC-119", Constants.BAD_REQUEST, "Current password is invalid"),
 
   INVALID_LOGIN_CREDENTIALS(400, "EC-120", Constants.BAD_REQUEST, "Invalid email or password."),

--- a/oauth-scim-module/oauth-scim-service/src/main/java/com/google/cloud/healthcare/fdamystudies/oauthscim/service/UserServiceImpl.java
+++ b/oauth-scim-module/oauth-scim-service/src/main/java/com/google/cloud/healthcare/fdamystudies/oauthscim/service/UserServiceImpl.java
@@ -183,11 +183,20 @@ public class UserServiceImpl implements UserService {
       return new ResetPasswordResponse(ErrorCode.USER_NOT_FOUND);
     }
 
+    UserEntity userEntity = entity.get();
+    if (userEntity.getStatus() == UserAccountStatus.PENDING_CONFIRMATION.getStatus()) {
+      throw new ErrorCodeException(ErrorCode.ACCOUNT_NOT_VERIFIED);
+    }
+
+    if (userEntity.getStatus() == UserAccountStatus.DEACTIVATED.getStatus()) {
+      throw new ErrorCodeException(ErrorCode.ACCOUNT_DEACTIVATED);
+    }
+
     String tempPassword = PasswordGenerator.generate(TEMP_PASSWORD_LENGTH);
     EmailResponse emailResponse = sendPasswordResetEmail(resetPasswordRequest, tempPassword);
 
     if (HttpStatus.ACCEPTED.value() == emailResponse.getHttpStatusCode()) {
-      UserEntity userEntity = entity.get();
+
       ObjectNode userInfo = (ObjectNode) userEntity.getUserInfo();
       setPasswordAndPasswordHistoryFields(tempPassword, userInfo, userEntity.getStatus());
       userEntity.setUserInfo(userInfo);


### PR DESCRIPTION
Issue #864 Only registered users who are verified will be able to get a temporary password when forgot password is selected. If User who is yet to be verified selects forgot password then the error message as described in the ticket will be displayed.