### PR TITLE
[Enrollment Service]:Issue 1796 fixed, Participant enroll datastore fails to start 

### DIFF
--- a/participant-datastore/enroll-mgmt-module/enroll-mgmt/src/main/java/com/google/cloud/healthcare/fdamystudies/config/ApplicationPropertyConfiguration.java
+++ b/participant-datastore/enroll-mgmt-module/enroll-mgmt/src/main/java/com/google/cloud/healthcare/fdamystudies/config/ApplicationPropertyConfiguration.java
@@ -20,9 +20,6 @@ import org.springframework.context.annotation.Configuration;
 @ToString
 public class ApplicationPropertyConfiguration {
 
-  @Value("${response.server.url}")
-  private String responseServerUrl;
-
   @Value("${response.server.url.participant.add}")
   private String addParticipantId;
 


### PR DESCRIPTION
Issue #1796 fixes

- Removed `@Value("${response.server.url}")` in `ApplicationPropertyConfiguration`