### PR TITLE
iOS - Handle expired token error.

### DIFF
--- a/iOS/HPHC/HPHC/Networking/APIs/HydraAPI.swift
+++ b/iOS/HPHC/HPHC/Networking/APIs/HydraAPI.swift
@@ -101,7 +101,11 @@ struct HydraAPI {
           completion(false, .unwrapError)
         }
       } else {
-        completion(false, error)
+        if error?.code == HTTPError.internalServerError.rawValue {
+          completion(false, ApiError.sessionExpiredError)
+        } else {
+          completion(false, error)
+        }
       }
     }
   }

--- a/iOS/HPHC/HPHC/Networking/Configurations/Environment/APIError.swift
+++ b/iOS/HPHC/HPHC/Networking/Configurations/Environment/APIError.swift
@@ -79,6 +79,7 @@ enum HTTPError: Int {
   case tokenExpired = 401
   case forbidden = 403
   case badRequest = 400
+  case internalServerError = 500
 
   var description: String? {
     switch self {


### PR DESCRIPTION
fixes an issue where App wasn't handling session expired due to expired token.
closes #1864 