### PR TITLE
iOS - Update SwiftLint

### DIFF
--- a/.github/workflows/lint-iOS.yml
+++ b/.github/workflows/lint-iOS.yml
@@ -14,4 +14,4 @@ jobs:
       - name: GitHub Action for SwiftLint
         uses: norio-nomura/action-swiftlint@3.1.0
         with:
-          args: --path iOS/HPHC --config .swiftlint.yml
+          args: --path iOS/HPHC --config iOS/HPHC/.swiftlint.yml

--- a/iOS/HPHC/.swiftlint.yml
+++ b/iOS/HPHC/.swiftlint.yml
@@ -1,5 +1,5 @@
 included:
-  - HPHC 
+  - iOS/HPHC 
 disabled_rules:
   - type_body_length
   - function_body_length
@@ -28,11 +28,3 @@ line_length:
   ignores_comments: true
   warning: 140
   error: 150
-identifier_name:
-  min_length:
-    error: 1
-    warning: 1
-type_name:
-  min_length:
-    error: 1
-    warning: 1


### PR DESCRIPTION
There was a new release for SwiftLint action which was breaking the existing script. This include changes to adapt to new release.