### PR TITLE
Separate deployment domain for studybuilder and participant-manager

### DIFF
--- a/Android/api.properties
+++ b/Android/api.properties
@@ -6,27 +6,27 @@
 API_KEY=""
 
 # URL of study datastore server.
-# e.g. https://mystudiesdeployment.com/study-datastore
+# e.g. https://studies.mystudiesdeployment.com/study-datastore
 BASE_URL_STUDY_DATASTORE=""
 
 # URL of different service bundles within participant datastore.
-# e.g. https://mystudiesdeployment.com/participant-user-datastore
+# e.g. https://participants.mystudiesdeployment.com/participant-user-datastore
 BASE_URL_PARTICIPANT_DATASTORE=""
-# e.g. https://mystudiesdeployment.com/participant-consent-datastore
+# e.g. https://participants.mystudiesdeployment.com/participant-consent-datastore
 BASE_URL_PARTICIPANT_CONSENT_DATASTORE=""
-# e.g. https://mystudiesdeployment.com/participant-enroll-datastore
+# e.g. https://participants.mystudiesdeployment.com/participant-enroll-datastore
 BASE_URL_PARTICIPANT_ENROLLMENT_DATASTORE=""
 
 # URL of Hydra Server.
-# e.g. https://mystudiesdeployment.com
+# e.g. https://participants.mystudiesdeployment.com
 BASE_URL_HYDRA_SERVER=""
 
 # URL of oauth scim service.
-# e.g. https://mystudiesdeployment.com/oauth-scim-service
+# e.g. https://participants.mystudiesdeployment.com/oauth-scim-service
 BASE_URL_AUTH_SERVER=""
 
 # URL of response datastore.
-# e.g. https://mystudiesdeployment.com/response-datastore
+# e.g. https://participants.mystudiesdeployment.com/response-datastore
 BASE_URL_RESPONSE_DATASTORE=""
 
 # Hydra ClientId for oauth-scim-service of the application.

--- a/iOS/MyStudies/MyStudies/Default.xcconfig
+++ b/iOS/MyStudies/MyStudies/Default.xcconfig
@@ -17,27 +17,27 @@
 // Set `Allow Arbitrary Loads` to NO and `Allow Arbitrary Loads in Web Content` to NO to connect over HTTPS
 
 // URL of study datastore server.
-// e.g. mystudiesdeployment.com/study-datastore
+// e.g. studies.mystudiesdeployment.com/study-datastore
 STUDY_DATASTORE_URL = xxxxxx
 
 // URL of response datastore.
-// e.g. mystudiesdeployment.com/response-datastore
+// e.g. participants.mystudiesdeployment.com/response-datastore
 RESPONSE_DATASTORE_URL = xxxxxxxxx
 
 // URL of different service bundles within participant datastore.
-// e.g. mystudiesdeployment.com/participant-user-datastore
+// e.g. participants.mystudiesdeployment.com/participant-user-datastore
 USER_DATASTORE_URL = xxxxxxx
-// e.g. mystudiesdeployment.com/participant-enroll-datastore
+// e.g. participants.mystudiesdeployment.com/participant-enroll-datastore
 ENROLLMENT_DATASTORE_URL = xxxxxx
-// e.g. mystudiesdeployment.com/participant-consent-datastore
+// e.g. participants.mystudiesdeployment.com/participant-consent-datastore
 CONSENT_DATASTORE_URL = xxxxxx
 
 // URL of oauth scim services.
-// e.g. mystudiesdeployment.com/oauth-scim-service
+// e.g. participants.mystudiesdeployment.com/oauth-scim-service
 AUTH_URL = xxxxxx
 
 // URL of Hydra server.
-// e.g. mystudiesdeployment.com
+// e.g. participants.mystudiesdeployment.com
 HYDRA_BASE_URL = xxxxx
 
 // HYDRA_CLIENT_ID is a client ID for OAuth.

--- a/kubernetes/cert.yaml
+++ b/kubernetes/cert.yaml
@@ -6,7 +6,15 @@
 apiVersion: networking.gke.io/v1beta1
 kind: ManagedCertificate
 metadata:
-  name: fda-mystudies-cert
+  name: fda-mystudies-cert-participants
 spec:
   domains:
-    - fda-mystudies.domain.com
+    - participants.fda-mystudies.domain.com
+---
+apiVersion: networking.gke.io/v1beta1
+kind: ManagedCertificate
+metadata:
+  name: fda-mystudies-cert-studies
+spec:
+  domains:
+    - studies.fda-mystudies.domain.com

--- a/kubernetes/ingress.yaml
+++ b/kubernetes/ingress.yaml
@@ -9,7 +9,7 @@ metadata:
   name: fda-mystudies-dev
   annotations:
     kubernetes.io/ingress.global-static-ip-name: mystudies-ingress-ip
-    networking.gke.io/managed-certificates: fda-mystudies-cert
+    networking.gke.io/managed-certificates: fda-mystudies-cert-participants,fda-mystudies-cert-studies
 spec:
   rules:
     - http:

--- a/mystudies.hcl
+++ b/mystudies.hcl
@@ -602,19 +602,22 @@ template "project_apps" {
         { account_id = "participant-manager-gke-sa" },
         { account_id = "triggers-pubsub-handler-gke-sa" },
       ]
-      # Adding Logs Writer permission to service accounts for application level audit logs
-      "roles/logging.logWriter " = [
-        "serviceAccount:$${google_service_account.auth_server_gke_sa.account_id}@{{$prefix}}-{{$env}}-apps.iam.gserviceaccount.com",
-        "serviceAccount:$${google_service_account.hydra_gke_sa.account_id}@{{$prefix}}-{{$env}}-apps.iam.gserviceaccount.com",
-        "serviceAccount:$${google_service_account.response_datastore_gke_sa.account_id}@{{$prefix}}-{{$env}}-apps.iam.gserviceaccount.com",
-        "serviceAccount:$${google_service_account.study_builder_gke_sa.account_id}@{{$prefix}}-{{$env}}-apps.iam.gserviceaccount.com",
-        "serviceAccount:$${google_service_account.study_datastore_gke_sa.account_id}@{{$prefix}}-{{$env}}-apps.iam.gserviceaccount.com",
-        "serviceAccount:$${google_service_account.consent_datastore_gke_sa.account_id}@{{$prefix}}-{{$env}}-apps.iam.gserviceaccount.com",
-        "serviceAccount:$${google_service_account.enroll_datastore_gke_sa.account_id}@{{$prefix}}-{{$env}}-apps.iam.gserviceaccount.com",
-        "serviceAccount:$${google_service_account.user_datastore_gke_sa.account_id}@{{$prefix}}-{{$env}}-apps.iam.gserviceaccount.com",
-        "serviceAccount:$${google_service_account.participant_manager_gke_sa.account_id}@{{$prefix}}-{{$env}}-apps.iam.gserviceaccount.com",
-        "serviceAccount:$${google_service_account.triggers_pubsub_handler_gke_sa.account_id}@{{$prefix}}-{{$env}}-apps.iam.gserviceaccount.com",
-      ]
+      # Step 5.7: uncomment and re-run the engine once all previous steps have been completed.
+      # iam_members = {
+      #  Adding Logs Writer permission to service accounts for application level audit logs
+      #   "roles/logging.logWriter" = [
+      #     "serviceAccount:$${google_service_account.auth_server_gke_sa.account_id}@{{.prefix}}-{{.env}}-apps.iam.gserviceaccount.com",
+      #     "serviceAccount:$${google_service_account.hydra_gke_sa.account_id}@{{.prefix}}-{{.env}}-apps.iam.gserviceaccount.com",
+      #     "serviceAccount:$${google_service_account.response_datastore_gke_sa.account_id}@{{.prefix}}-{{.env}}-apps.iam.gserviceaccount.com",
+      #     "serviceAccount:$${google_service_account.study_builder_gke_sa.account_id}@{{.prefix}}-{{.env}}-apps.iam.gserviceaccount.com",
+      #     "serviceAccount:$${google_service_account.study_datastore_gke_sa.account_id}@{{.prefix}}-{{.env}}-apps.iam.gserviceaccount.com",
+      #     "serviceAccount:$${google_service_account.consent_datastore_gke_sa.account_id}@{{.prefix}}-{{.env}}-apps.iam.gserviceaccount.com",
+      #     "serviceAccount:$${google_service_account.enroll_datastore_gke_sa.account_id}@{{.prefix}}-{{.env}}-apps.iam.gserviceaccount.com",
+      #     "serviceAccount:$${google_service_account.user_datastore_gke_sa.account_id}@{{.prefix}}-{{.env}}-apps.iam.gserviceaccount.com",
+      #     "serviceAccount:$${google_service_account.participant_manager_gke_sa.account_id}@{{.prefix}}-{{.env}}-apps.iam.gserviceaccount.com",
+      #     "serviceAccount:$${google_service_account.triggers_pubsub_handler_gke_sa.account_id}@{{.prefix}}-{{.env}}-apps.iam.gserviceaccount.com",
+      #   ]
+      # }
       # Binary Authorization resources.
       # Simple configuration for now. Future
       # See https://cloud.google.com/binary-authorization/docs/overview
@@ -629,7 +632,15 @@ template "project_apps" {
         domain = "{{.prefix}}-{{.env}}.{{.domain}}."
         type   = "public"
         record_sets = [{
-          name = "{{.prefix}}-{{.env}}"
+          name = "participants"
+          type = "A"
+          ttl  = 30
+          records = [
+            "$${google_compute_global_address.ingress_static_ip.address}",
+          ]
+        },
+        {
+          name = "studies"
           type = "A"
           ttl  = 30
           records = [
@@ -1023,7 +1034,8 @@ resource "kubernetes_secret" "shared_secrets" {
   data = {
     gcp_bucket_name                   = "{{.prefix}}-{{.env}}-mystudies-consent-documents"
     institution_resources_bucket_name = "{{.prefix}}-{{.env}}-mystudies-institution-resources"
-    base_url                          = "https://{{.prefix}}-{{.env}}.{{.domain}}."
+    base_url                          = "https://participants.{{.prefix}}-{{.env}}.{{.domain}}"
+    studies_base_url                  = "https://studies.{{.prefix}}-{{.env}}.{{.domain}}"
     firestore_project_id              = "{{.prefix}}-{{.env}}-firebase"
     log_path                          = data.google_secret_manager_secret_version.secrets["manual-log-path"].secret_data
     org_name                          = data.google_secret_manager_secret_version.secrets["manual-org-name"].secret_data

--- a/study-builder/tf-deployment.yaml
+++ b/study-builder/tf-deployment.yaml
@@ -95,7 +95,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: shared-secrets
-                  key: base_url
+                  key: studies_base_url
             - name: PARTICIPANT_USER_DATASTORE_URL
               value: "http://participant-user-datastore-np:50000/participant-user-datastore"
             - name: RESPONSE_DATASTORE_URL

--- a/study-datastore/tf-deployment.yaml
+++ b/study-datastore/tf-deployment.yaml
@@ -79,7 +79,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: shared-secrets
-                  key: base_url
+                  key: studies_base_url
             - name: TERMS_AND_CONDITION_URL
               valueFrom:
                 secretKeyRef:

--- a/terraform/example-dev-apps/main.tf
+++ b/terraform/example-dev-apps/main.tf
@@ -160,7 +160,13 @@ module "example_dev" {
 
   recordsets = [
     {
-      name    = "example-dev"
+      name    = "participants"
+      records = ["${google_compute_global_address.ingress_static_ip.address}"]
+      ttl     = 30
+      type    = "A"
+    },
+    {
+      name    = "studies"
       records = ["${google_compute_global_address.ingress_static_ip.address}"]
       ttl     = 30
       type    = "A"
@@ -196,6 +202,29 @@ module "example_dev_gke_cluster" {
   enable_private_endpoint = false
   release_channel         = "STABLE"
 
+}
+
+module "project_iam_members" {
+  source  = "terraform-google-modules/iam/google//modules/projects_iam"
+  version = "~> 6.3.0"
+
+  projects = [module.project.project_id]
+  mode     = "additive"
+
+  bindings = {
+    "roles/logging.logWriter" = [
+      "serviceAccount:${google_service_account.auth_server_gke_sa.account_id}@example-dev-apps.iam.gserviceaccount.com",
+      "serviceAccount:${google_service_account.hydra_gke_sa.account_id}@example-dev-apps.iam.gserviceaccount.com",
+      "serviceAccount:${google_service_account.response_datastore_gke_sa.account_id}@example-dev-apps.iam.gserviceaccount.com",
+      "serviceAccount:${google_service_account.study_builder_gke_sa.account_id}@example-dev-apps.iam.gserviceaccount.com",
+      "serviceAccount:${google_service_account.study_datastore_gke_sa.account_id}@example-dev-apps.iam.gserviceaccount.com",
+      "serviceAccount:${google_service_account.consent_datastore_gke_sa.account_id}@example-dev-apps.iam.gserviceaccount.com",
+      "serviceAccount:${google_service_account.enroll_datastore_gke_sa.account_id}@example-dev-apps.iam.gserviceaccount.com",
+      "serviceAccount:${google_service_account.user_datastore_gke_sa.account_id}@example-dev-apps.iam.gserviceaccount.com",
+      "serviceAccount:${google_service_account.participant_manager_gke_sa.account_id}@example-dev-apps.iam.gserviceaccount.com",
+      "serviceAccount:${google_service_account.triggers_pubsub_handler_gke_sa.account_id}@example-dev-apps.iam.gserviceaccount.com",
+    ],
+  }
 }
 
 resource "google_service_account" "auth_server_gke_sa" {

--- a/terraform/kubernetes/main.tf
+++ b/terraform/kubernetes/main.tf
@@ -131,7 +131,8 @@ resource "kubernetes_secret" "shared_secrets" {
   data = {
     gcp_bucket_name                   = "example-dev-mystudies-consent-documents"
     institution_resources_bucket_name = "example-dev-mystudies-institution-resources"
-    base_url                          = "https://example-dev.example.com."
+    base_url                          = "https://participants.example-dev.example.com"
+    studies_base_url                  = "https://studies.example-dev.example.com"
     firestore_project_id              = "example-dev-firebase"
     log_path                          = data.google_secret_manager_secret_version.secrets["manual-log-path"].secret_data
     org_name                          = data.google_secret_manager_secret_version.secrets["manual-org-name"].secret_data


### PR DESCRIPTION
also fixes minor terraform issues.

Separating the domain in order to prevent exfilteration issues from the old code to the new application.