### PR TITLE
[User management Service]Issue2170, When server fails to send mails to user while registering, "Email not exist" error is showing in the mobile app when user request for resend verification code.

### DIFF
--- a/participant-datastore/user-mgmt-module/user-mgmt/src/main/java/com/google/cloud/healthcare/fdamystudies/controller/UserProfileController.java
+++ b/participant-datastore/user-mgmt-module/user-mgmt/src/main/java/com/google/cloud/healthcare/fdamystudies/controller/UserProfileController.java
@@ -27,6 +27,7 @@ import com.google.cloud.healthcare.fdamystudies.common.MessageCode;
 import com.google.cloud.healthcare.fdamystudies.common.UserMgmntAuditHelper;
 import com.google.cloud.healthcare.fdamystudies.common.UserStatus;
 import com.google.cloud.healthcare.fdamystudies.config.ApplicationPropertyConfiguration;
+import com.google.cloud.healthcare.fdamystudies.exceptions.ErrorCodeException;
 import com.google.cloud.healthcare.fdamystudies.mapper.AuditEventMapper;
 import com.google.cloud.healthcare.fdamystudies.model.UserDetailsEntity;
 import com.google.cloud.healthcare.fdamystudies.service.CommonService;
@@ -213,6 +214,10 @@ public class UserProfileController {
                   VERIFICATION_EMAIL_RESEND_REQUEST_RECEIVED, auditRequest);
               responseBean.setMessage(
                   MyStudiesUserRegUtil.ErrorCodes.SUCCESS.getValue().toLowerCase());
+            } else {
+              throw new ErrorCodeException(
+                  com.google.cloud.healthcare.fdamystudies.common.ErrorCode
+                      .REGISTRATION_EMAIL_SEND_FAILED);
             }
           }
 

--- a/participant-datastore/user-mgmt-module/user-mgmt/src/main/java/com/google/cloud/healthcare/fdamystudies/dao/UserProfileManagementDaoImpl.java
+++ b/participant-datastore/user-mgmt-module/user-mgmt/src/main/java/com/google/cloud/healthcare/fdamystudies/dao/UserProfileManagementDaoImpl.java
@@ -145,7 +145,6 @@ public class UserProfileManagementDaoImpl implements UserProfileManagementDao {
     userDetailsPredicates.add(
         criteriaBuilder.equal(userDetailsBoRoot.get(AppConstants.EMAIL), email));
     userDetailsPredicates.add(criteriaBuilder.equal(userDetailsBoRoot.get("app"), app));
-    userDetailsPredicates.add(criteriaBuilder.notEqual(userDetailsBoRoot.get("emailCode"), "Null"));
     criteriaQuery
         .select(userDetailsBoRoot)
         .where(userDetailsPredicates.toArray(new Predicate[userDetailsPredicates.size()]));


### PR DESCRIPTION
Issue #2170 fixed.

- When email sending fails, `throw new ErrorCodeException(REGISTRATION_EMAIL_SEND_FAILED);`
- Remove `userDetailsPredicates.add(criteriaBuilder.notEqual(userDetailsBoRoot.get("emailCode"), "Null"));` because while registering if email sending failed then emailCode will be null.