### PR TITLE
Add plus minus accessory view.

### DIFF
--- a/iOS/MyStudies/ResearchKit/Common/ORKAnswerTextField.h
+++ b/iOS/MyStudies/ResearchKit/Common/ORKAnswerTextField.h
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 ORK_CLASS_AVAILABLE
 @interface ORKAnswerTextField : UITextField <ORKDefaultFont>
-
+- (void)addPlusMinusAccessoryView;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/iOS/MyStudies/ResearchKit/Common/ORKAnswerTextField.m
+++ b/iOS/MyStudies/ResearchKit/Common/ORKAnswerTextField.m
@@ -76,8 +76,31 @@
     self.inputAccessoryView = accessoryViewWithDoneButton;
 }
 
+- (void)addPlusMinusAccessoryView {
+  UIToolbar *toolBar = (UIToolbar *)self.inputAccessoryView;
+  NSArray<UIBarButtonItem *> *OldItems = toolBar.items;
+  UIBarButtonItem *plusMinus = [[UIBarButtonItem alloc]
+                                initWithTitle:ORKLocalizedString(@"+/-", nil)
+                                style:UIBarButtonItemStylePlain
+                                target:self
+                                action:@selector(keyboardAccessoryViewPlusMinusButtonPressed)];
+
+  NSMutableArray *newItems = [[NSMutableArray alloc] init];
+  [newItems addObject:plusMinus];
+  [newItems addObjectsFromArray:OldItems];
+  toolBar.items = newItems;
+}
+
 - (void)keyboardAccessoryViewDoneButtonPressed {
     [self resignFirstResponder];
+}
+
+- (void)keyboardAccessoryViewPlusMinusButtonPressed {
+  if ([self.text hasPrefix:@"-"]) {
+    self.text = [self.text substringFromIndex:1];
+  } else {
+    self.text = [NSString stringWithFormat:@"-%@",self.text];
+  }
 }
 
 - (void)updateAppearance {

--- a/iOS/MyStudies/ResearchKit/Common/ORKFormItemCell.m
+++ b/iOS/MyStudies/ResearchKit/Common/ORKFormItemCell.m
@@ -788,6 +788,10 @@ static const CGFloat HorizontalMargin = 15.0;
     [super cellInit];
     ORKQuestionType questionType = [self.formItem questionType];
     self.textField.keyboardType = (questionType == ORKQuestionTypeInteger) ? UIKeyboardTypeNumberPad : UIKeyboardTypeDecimalPad;
+    if (questionType == ORKQuestionTypeDecimal ||
+        questionType == ORKQuestionTypeInteger) {
+        (void)self.textField.addPlusMinusAccessoryView;
+    }
     [self.textField addTarget:self action:@selector(valueFieldDidChange:) forControlEvents:UIControlEventEditingChanged];
     self.textField.allowsSelection = YES;
     

--- a/iOS/MyStudies/ResearchKit/Common/ORKSurveyAnswerCellForNumber.m
+++ b/iOS/MyStudies/ResearchKit/Common/ORKSurveyAnswerCellForNumber.m
@@ -70,8 +70,10 @@
     
     if (questionType == ORKQuestionTypeDecimal) {
         textField.keyboardType = UIKeyboardTypeDecimalPad;
+        (void)textField.addPlusMinusAccessoryView;
     } else if (questionType == ORKQuestionTypeInteger) {
         textField.keyboardType = UIKeyboardTypeNumberPad;
+        (void)textField.addPlusMinusAccessoryView;
     }
     
     [textField addTarget:self action:@selector(valueFieldDidChange:) forControlEvents:UIControlEventEditingChanged];


### PR DESCRIPTION
fixes #1525 

I've added a button on the toolbar which is above the keyboard to make the value positive/negative as there's no numeric keyboard type that has the negative key.

![Simulator Screen Shot - iPhone 11 - 2020-12-07 at 15 32 41](https://user-images.githubusercontent.com/44088109/101471782-b83a9e80-396d-11eb-9bb8-2551117e77a4.png)
