### PR TITLE
[Study Builder]Issue #2415 fixed, Fix study builder error message

### DIFF
--- a/study-builder/fdahpStudyDesigner/src/main/webapp/WEB-INF/view/study/basicInformation.jsp
+++ b/study-builder/fdahpStudyDesigner/src/main/webapp/WEB-INF/view/study/basicInformation.jsp
@@ -1063,7 +1063,8 @@
                     .empty()
                     .append($("<ul><li> </li></ul>").attr("class","list-unstyled").text(
                         appId
-                        + " has already been used in the past.</li></ul>"));
+                        + " has already been used in the past. Switch app type to 'gateway' or choose a unique App ID."))
+                    .append("</br>");
                 callback(false);
               }
             },


### PR DESCRIPTION
Issue #2415 fixed

Removed `</li></ul>` element which was appended to error message.
Changed text `"This App ID has already been used. Switch app type to 'gateway' or choose a unique App ID."`