### PR TITLE
Update main.tf with more permissive terraform versions

### DIFF
--- a/deployment/terraform/devops/main.tf
+++ b/deployment/terraform/devops/main.tf
@@ -22,7 +22,7 @@
 
 // TODO: replace with https://github.com/terraform-google-modules/terraform-google-bootstrap
 terraform {
-  required_version = "~> 0.12.0"
+  required_version = "> 0.12.0"
   required_providers {
     google      = "~> 3.0"
     google-beta = "~> 3.0"


### PR DESCRIPTION
This enables installation of v 0.13.5 as recommended in the [data protection guide](https://github.com/GoogleCloudPlatform/healthcare-data-protection-suite/tree/master/docs/tfengine/#prerequisites)