### PR TITLE
[Participant Datastore] Changes to configure email code expiry time

### DIFF
--- a/participant-datastore/enroll-mgmt-module/enroll-mgmt/src/main/resources/application.properties
+++ b/participant-datastore/enroll-mgmt-module/enroll-mgmt/src/main/resources/application.properties
@@ -59,8 +59,6 @@ commonservice.email.enabled = false
 
 component.name=PARTICIPANT ENROLL DATASTORE
 
-email.code.expire_time = 15
-
 spring.datasource.driverClassName=com.mysql.jdbc.Driver
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5InnoDBDialect
 spring.jpa.hibernate.naming.strategy=org.hibernate.cfg.ImprovedNamingStrategy

--- a/participant-datastore/user-mgmt-module/user-mgmt/src/main/java/com/google/cloud/healthcare/fdamystudies/service/UserRegistrationServiceImpl.java
+++ b/participant-datastore/user-mgmt-module/user-mgmt/src/main/java/com/google/cloud/healthcare/fdamystudies/service/UserRegistrationServiceImpl.java
@@ -182,7 +182,7 @@ public class UserRegistrationServiceImpl implements UserRegistrationService {
     EmailResponse emailResponse = sendConfirmationEmail(userDetails, verificationCode);
     if (MessageCode.EMAIL_ACCEPTED_BY_MAIL_SERVER.getMessage().equals(emailResponse.getMessage())) {
       userDetails.setEmailCode(verificationCode);
-      userDetails.setCodeExpireDate(Timestamp.valueOf(LocalDateTime.now().plusMinutes(expireTime)));
+      userDetails.setCodeExpireDate(Timestamp.valueOf(LocalDateTime.now().plusHours(expireTime)));
       userDetailsRepository.saveAndFlush(userDetails);
     }
     return emailResponse;

--- a/participant-datastore/user-mgmt-module/user-mgmt/src/main/resources/application.properties
+++ b/participant-datastore/user-mgmt-module/user-mgmt/src/main/resources/application.properties
@@ -15,7 +15,7 @@ spring.main.allow-bean-definition-overriding=true
 logging.level.root=WARN
 logging.level.com.google.cloud.healthcare.fdamystudies=WARN
 
-email.code.expire_time = 15
+email.code.expire_time = 48
 
 # Refer https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-configuration-properties.html
 spring.datasource.url=jdbc:mysql://${DB_INSTANCE_URL}:3306/${DB_NAME}
@@ -72,7 +72,7 @@ response.server.url.participant.withdraw=${RESPONSE_DATASTORE_URL}/participant/w
 
 # Feedback & Contactus mail content ends
 confirmation.mail.subject=Welcome to the {{appName}} App!
-confirmation.mail.content=<html><body><div style='margin:20px;padding:10px;font-family: sans-serif;font-size: 14px;'><span>Hi,</span><br/><br/><span>Thank you for registering your account with the {{appName}} app!</span><br/><br/><span>Your sign-up process is almost complete. Please use the verification code provided below to <br/>complete the verification step in the mobile app.</span><br/><br/><span><strong>Verification Code:</strong><b>{{securitytoken}}</b> </span></span><br/><br/><span>This code can be used only once and is valid for a period of 48 hours only.</span><br/><br/><span>For any questions or assistance, please write to <a>{{contactEmail}}</a> </span><br/><br/><span style='font-size:15px;'>Thanks,</span><br/><span>The {{appName}} support team</span><br/><span>----------------------------------------------------</span><br/><span style='font-size:10px;'>Note: This is an auto-generated email. Please do not reply.</span></div></body></html>
+confirmation.mail.content=<html><body><div style='margin:20px;padding:10px;font-family: sans-serif;font-size: 14px;'><span>Hi,</span><br/><br/><span>Thank you for registering your account with the {{appName}} app!</span><br/><br/><span>Your sign-up process is almost complete. Please use the verification code provided below to <br/>complete the verification step in the mobile app.</span><br/><br/><span><strong>Verification Code:</strong><b>{{securitytoken}}</b> </span></span><br/><br/><span>This code can be used only once and is valid for a period of %{email.code.expire_time} hours only.</span><br/><br/><span>For any questions or assistance, please write to <a>{{contactEmail}}</a> </span><br/><br/><span style='font-size:15px;'>Thanks,</span><br/><span>The {{appName}} support team</span><br/><span>----------------------------------------------------</span><br/><span style='font-size:10px;'>Note: This is an auto-generated email. Please do not reply.</span></div></body></html>
 
 # Feedback & Contactus mail content starts
 feedback.email=${MAIL_CONTACT_EMAIL}

--- a/participant-datastore/user-mgmt-module/user-mgmt/src/test/resources/data.sql
+++ b/participant-datastore/user-mgmt-module/user-mgmt/src/test/resources/data.sql
@@ -22,4 +22,4 @@ INSERT INTO `app_permissions` (`id`, `created_time`, `created_by`, `edit`, `app_
 
 INSERT INTO `study_permissions` (`id`, `created_time`, `created_by`, `edit`, `app_info_id`, `study_id`, `ur_admin_user_id`) VALUES ('1', '2020-08-05 18:43:33', '0', '1', '1', '1', '1');
 
-INSERT INTO `sites_permissions` (`id`, `created_time`, `created_by`, `edit`, `app_info_id`, `study_id`, `site_id`, `ur_admin_user_id`) VALUES ('1', '2020-08-05 18:43:33', '0', '1', '1', '1', '1');
+INSERT INTO `sites_permissions` (`id`, `created_time`, `created_by`, `edit`, `app_info_id`, `study_id`, `site_id`, `ur_admin_user_id`) VALUES ('1', '2020-08-05 18:43:33', '1', '0', '1', '1', '1', '1');


### PR DESCRIPTION
Changes made to include expire time dynamic for email content in participant user datastore . Please refer issue #2439 


`**email.code.expire_time** = 48`
`confirmation.mail.content=<html><body><div style='margin:20px;padding:10px;font-family: sans-serif;font-size: 14px;'><span>Hi,</span><br/><br/><span>Thank you for registering your account with the {{appName}} app!</span><br/><br/><span>Your sign-up process is almost complete. Please use the verification code provided below to <br/>complete the verification step in the mobile app.</span><br/><br/><span><strong>Verification Code:</strong><b>{{securitytoken}}</b> </span></span><br/><br/><span>This code can be used only once and is valid for a period of **%{email.code.expire_time}** hours only.</span><br/><br/><span>For any questions or assistance, please write to <a>{{contactEmail}}</a> </span><br/><br/><span style='font-size:15px;'>Thanks,</span><br/><span>The {{appName}} support team</span><br/><span>----------------------------------------------------</span><br/><span style='font-size:10px;'>Note: This is an auto-generated email. Please do not reply.</span></div></body></html>`