### PR TITLE
Fixed issue #2661 [Mobile] Html breaking in Resources Text 

### DIFF
--- a/study-builder/fdahpStudyDesigner/src/main/webapp/WEB-INF/view/study/addOrEditResourcePage.jsp
+++ b/study-builder/fdahpStudyDesigner/src/main/webapp/WEB-INF/view/study/addOrEditResourcePage.jsp
@@ -380,9 +380,6 @@
               if (valid) {
                 console.log(1);
                 $('#buttonText').val('done');
-                var editorText = $('#richText').summernote('code');
-                var escaped = $('#richText').text(editorText).html();
-                $('#richText').val(escaped);
                 $('#resourceForm').submit();
               } else {
                 console.log(2);
@@ -392,9 +389,6 @@
           });
         } else {
           $('#buttonText').val('done');
-          var editorText = $('#richText').summernote('code');
-          var escaped = $('#richText').text(editorText).html();
-          $('#richText').val(escaped);
           $('#resourceForm').submit();
         }
       } else {
@@ -463,12 +457,6 @@
         $('#resourceForm').validator('destroy');
         $("#actionOn").val(actionOn);
         $("#buttonText").val('save');
-        var editorTextVal = $('#richText').val();
-        if (null != editorTextVal && editorTextVal != '' && typeof editorTextVal != 'undefined' && editorTextVal != '<p><br></p>'){
-        	var editorText = $('#richText').summernote('code');
-      	    var escaped = $('#richText').text(editorText).html();
-      	    $('#richText').val(escaped);
-        }
         $('#resourceForm').submit();
       }
       $('#saveResourceId').prop('disabled', false);


### PR DESCRIPTION
Fixed issue #2661 [Mobile] Html breaking in Resources Text.
Converting the HTML tag to text was causing the issue in mobile app.
HTML tags were getting saved as text format `&lt;p&gt;btc&lt;b&gt;`, so removed those piece of code.

Screenshot after fix:
<img width="393" alt="Screenshot (40)" src="https://user-images.githubusercontent.com/69199888/103751517-782f1000-502e-11eb-9185-289e6fbb7fe1.png">
