### PR TITLE
Fix for 2339

### DIFF
--- a/response-datastore/tf-deployment.yaml
+++ b/response-datastore/tf-deployment.yaml
@@ -71,7 +71,7 @@ spec:
             - name: STUDY_DATASTORE_URL
               value: "http://study-datastore-np:50000/study-datastore"
             - name: PARTICIPANT_ENROLL_DATASTORE_URL
-              value: "http://participant-enroll-datastore:50000/participant-enroll-datastore"
+              value: "http://participant-enroll-datastore-np:50000/participant-enroll-datastore"
             - name: HYDRA_ADMIN_URL
               value: "http://hydra-admin-np:50000"
             - name: SCIM_AUTH_URL


### PR DESCRIPTION
Terraform deployment for Response Datastore does not use the correct node port path for Enroll Service. Updated this value and tested. This resolves #2339 and I have confirmed that response data is now correctly showing in Firestore.