### PR TITLE
Fixed issues #2325, #2852 and #2820, oauth server- audit logs and UI issues

### DIFF
--- a/auth-server/oauth-scim-service/src/main/java/com/google/cloud/healthcare/fdamystudies/oauthscim/common/AuthScimConstants.java
+++ b/auth-server/oauth-scim-service/src/main/java/com/google/cloud/healthcare/fdamystudies/oauthscim/common/AuthScimConstants.java
@@ -121,13 +121,11 @@ public final class AuthScimConstants {
 
   public static final String APP_NAME_COOKIE = "mystudies_appName";
 
-  public static final String APP_VERSION_COOKIE = "mystudies_appVersion";
-
   public static final String LOGIN_CHALLENGE_COOKIE = "mystudies_login_challenge";
 
   public static final String CORRELATION_ID_COOKIE = "mystudies_correlationId";
 
-  public static final String CLIENT_APP_VERSION_COOKIE = "mystudies_clientAppVersion";
+  public static final String APP_VERSION_COOKIE = "mystudies_appVersion";
 
   public static final String USER_ID_COOKIE = "mystudies_userId";
 

--- a/auth-server/oauth-scim-service/src/main/java/com/google/cloud/healthcare/fdamystudies/oauthscim/common/AuthScimConstants.java
+++ b/auth-server/oauth-scim-service/src/main/java/com/google/cloud/healthcare/fdamystudies/oauthscim/common/AuthScimConstants.java
@@ -121,6 +121,8 @@ public final class AuthScimConstants {
 
   public static final String APP_NAME_COOKIE = "mystudies_appName";
 
+  public static final String APP_VERSION_COOKIE = "mystudies_appVersion";
+
   public static final String LOGIN_CHALLENGE_COOKIE = "mystudies_login_challenge";
 
   public static final String CORRELATION_ID_COOKIE = "mystudies_correlationId";

--- a/auth-server/oauth-scim-service/src/main/java/com/google/cloud/healthcare/fdamystudies/oauthscim/controller/CallbackController.java
+++ b/auth-server/oauth-scim-service/src/main/java/com/google/cloud/healthcare/fdamystudies/oauthscim/controller/CallbackController.java
@@ -9,6 +9,7 @@
 package com.google.cloud.healthcare.fdamystudies.oauthscim.controller;
 
 import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimConstants.ACCOUNT_STATUS_COOKIE;
+import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimConstants.APP_VERSION_COOKIE;
 import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimConstants.ERROR_VIEW_NAME;
 import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimConstants.MOBILE_PLATFORM_COOKIE;
 import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimConstants.SOURCE_COOKIE;
@@ -82,6 +83,7 @@ public class CallbackController {
     String accountStatus = cookieHelper.getCookieValue(request, ACCOUNT_STATUS_COOKIE);
     String source = cookieHelper.getCookieValue(request, SOURCE_COOKIE);
     String callbackUrl = redirectConfig.getCallbackUrl(mobilePlatform, source);
+    String appVersion = cookieHelper.getCookieValue(request, APP_VERSION_COOKIE);
 
     String redirectUrl = null;
     if (StringUtils.equals(
@@ -100,6 +102,7 @@ public class CallbackController {
               "%s?code=%s&userId=%s&accountStatus=%s", callbackUrl, code, userId, accountStatus);
     }
 
+    auditRequest.setAppVersion(appVersion);
     if (UserAccountStatus.ACTIVE.getStatus() == Integer.parseInt(accountStatus)) {
       auditHelper.logEvent(SIGNIN_SUCCEEDED, auditRequest);
     } else {

--- a/auth-server/oauth-scim-service/src/main/java/com/google/cloud/healthcare/fdamystudies/oauthscim/controller/CallbackController.java
+++ b/auth-server/oauth-scim-service/src/main/java/com/google/cloud/healthcare/fdamystudies/oauthscim/controller/CallbackController.java
@@ -102,7 +102,6 @@ public class CallbackController {
               "%s?code=%s&userId=%s&accountStatus=%s", callbackUrl, code, userId, accountStatus);
     }
 
-    auditRequest.setAppVersion(appVersion);
     if (UserAccountStatus.ACTIVE.getStatus() == Integer.parseInt(accountStatus)) {
       auditHelper.logEvent(SIGNIN_SUCCEEDED, auditRequest);
     } else {

--- a/auth-server/oauth-scim-service/src/main/java/com/google/cloud/healthcare/fdamystudies/oauthscim/controller/LoginController.java
+++ b/auth-server/oauth-scim-service/src/main/java/com/google/cloud/healthcare/fdamystudies/oauthscim/controller/LoginController.java
@@ -13,6 +13,7 @@ import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScim
 import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimConstants.ACCOUNT_STATUS_COOKIE;
 import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimConstants.APP_ID_COOKIE;
 import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimConstants.APP_NAME_COOKIE;
+import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimConstants.APP_VERSION_COOKIE;
 import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimConstants.AUTO_LOGIN_VIEW_NAME;
 import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimConstants.CLIENT_APP_VERSION_COOKIE;
 import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimConstants.CORRELATION_ID_COOKIE;
@@ -156,7 +157,9 @@ public class LoginController {
     String mobilePlatform = cookieHelper.getCookieValue(request, MOBILE_PLATFORM_COOKIE);
     String source = cookieHelper.getCookieValue(request, SOURCE_COOKIE);
     String appName = cookieHelper.getCookieValue(request, APP_NAME_COOKIE);
+    String appVersion = cookieHelper.getCookieValue(request, APP_VERSION_COOKIE);
 
+    auditRequest.setAppVersion(appVersion);
     boolean attrsAdded = addAttributesToModel(model, mobilePlatform, source);
     if (!attrsAdded) {
       return ERROR_VIEW_NAME;
@@ -252,7 +255,8 @@ public class LoginController {
         CLIENT_APP_VERSION_COOKIE,
         MOBILE_PLATFORM_COOKIE,
         SOURCE_COOKIE,
-        APP_NAME_COOKIE);
+        APP_NAME_COOKIE,
+        APP_VERSION_COOKIE);
 
     String mobilePlatform = qsParams.getFirst(MOBILE_PLATFORM);
     String source = qsParams.getFirst(SOURCE);

--- a/auth-server/oauth-scim-service/src/main/java/com/google/cloud/healthcare/fdamystudies/oauthscim/controller/LoginController.java
+++ b/auth-server/oauth-scim-service/src/main/java/com/google/cloud/healthcare/fdamystudies/oauthscim/controller/LoginController.java
@@ -15,7 +15,6 @@ import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScim
 import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimConstants.APP_NAME_COOKIE;
 import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimConstants.APP_VERSION_COOKIE;
 import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimConstants.AUTO_LOGIN_VIEW_NAME;
-import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimConstants.CLIENT_APP_VERSION_COOKIE;
 import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimConstants.CORRELATION_ID_COOKIE;
 import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimConstants.ERROR_DESCRIPTION;
 import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimConstants.ERROR_VIEW_NAME;
@@ -157,9 +156,7 @@ public class LoginController {
     String mobilePlatform = cookieHelper.getCookieValue(request, MOBILE_PLATFORM_COOKIE);
     String source = cookieHelper.getCookieValue(request, SOURCE_COOKIE);
     String appName = cookieHelper.getCookieValue(request, APP_NAME_COOKIE);
-    String appVersion = cookieHelper.getCookieValue(request, APP_VERSION_COOKIE);
 
-    auditRequest.setAppVersion(appVersion);
     boolean attrsAdded = addAttributesToModel(model, mobilePlatform, source);
     if (!attrsAdded) {
       return ERROR_VIEW_NAME;
@@ -252,11 +249,10 @@ public class LoginController {
         qsParams,
         APP_ID_COOKIE,
         CORRELATION_ID_COOKIE,
-        CLIENT_APP_VERSION_COOKIE,
+        APP_VERSION_COOKIE,
         MOBILE_PLATFORM_COOKIE,
         SOURCE_COOKIE,
-        APP_NAME_COOKIE,
-        APP_VERSION_COOKIE);
+        APP_NAME_COOKIE);
 
     String mobilePlatform = qsParams.getFirst(MOBILE_PLATFORM);
     String source = qsParams.getFirst(SOURCE);

--- a/auth-server/oauth-scim-service/src/main/resources/static/css/style.css
+++ b/auth-server/oauth-scim-service/src/main/resources/static/css/style.css
@@ -240,7 +240,7 @@ footer ul li:last-child a {
 
 .cmn__error {
   position: absolute;
-  bottom: 10%;
+  bottom: 50%;
   background: #f44336;
   padding: 3px 6px;
   color: #fff;

--- a/auth-server/oauth-scim-service/src/main/resources/static/css/style.css
+++ b/auth-server/oauth-scim-service/src/main/resources/static/css/style.css
@@ -240,7 +240,7 @@ footer ul li:last-child a {
 
 .cmn__error {
   position: absolute;
-  bottom: 50%;
+  bottom: 25%;
   background: #f44336;
   padding: 3px 6px;
   color: #fff;

--- a/auth-server/oauth-scim-service/src/main/resources/templates/autoLogin.html
+++ b/auth-server/oauth-scim-service/src/main/resources/templates/autoLogin.html
@@ -31,6 +31,7 @@
   font-family: Muli,sans-serif !important;
   font-weight: 600 !important;
   text-align: center !important;
+  margin-top: 100% !important;
  }
 </style>
 </head>

--- a/auth-server/oauth-scim-service/src/main/resources/templates/autoLogin.html
+++ b/auth-server/oauth-scim-service/src/main/resources/templates/autoLogin.html
@@ -28,7 +28,6 @@
 <style type="text/css">
 .child_text  { 
   color: #353a3e !important;
-  font-size: 100% !important;
   font-family: Muli,sans-serif !important;
   font-weight: 600 !important;
   text-align: center !important;

--- a/auth-server/oauth-scim-service/src/main/resources/templates/consent.html
+++ b/auth-server/oauth-scim-service/src/main/resources/templates/consent.html
@@ -31,6 +31,7 @@
   font-family: Muli,sans-serif !important;
   font-weight: 600 !important;
   text-align: center !important;
+  margin-top: 100% !important;
  }
 </style>
 </head>

--- a/auth-server/oauth-scim-service/src/main/resources/templates/consent.html
+++ b/auth-server/oauth-scim-service/src/main/resources/templates/consent.html
@@ -28,7 +28,6 @@
 <style type="text/css">
 .child_text  { 
   color: #353a3e !important;
-  font-size: 100% !important;
   font-family: Muli,sans-serif !important;
   font-weight: 600 !important;
   text-align: center !important;

--- a/auth-server/oauth-scim-service/src/main/resources/templates/error.html
+++ b/auth-server/oauth-scim-service/src/main/resources/templates/error.html
@@ -30,7 +30,6 @@
 
   .child_text { 
     color: #353a3e !important;
-    font-size: 100% !important;
     font-family: Muli,sans-serif !important;
     font-weight: 600 !important;
     text-align: center !important;
@@ -38,7 +37,6 @@
 }
 .child_text { 
   color: #353a3e !important;
-  font-size: 100% !important;
   font-family: Muli,sans-serif !important;
   font-weight: 600 !important;
   text-align: center !important;

--- a/auth-server/oauth-scim-service/src/main/resources/templates/error.html
+++ b/auth-server/oauth-scim-service/src/main/resources/templates/error.html
@@ -33,6 +33,7 @@
     font-family: Muli,sans-serif !important;
     font-weight: 600 !important;
     text-align: center !important;
+    margin-top: 100% !important;
    }
 }
 .child_text { 
@@ -40,6 +41,7 @@
   font-family: Muli,sans-serif !important;
   font-weight: 600 !important;
   text-align: center !important;
+  margin-top: 100% !important;
 }
 </style>
 
@@ -49,7 +51,7 @@
     <div class="width__110">
       <img th:src="@{/images/ErrorIcon.svg}" alt="error image " class="mb-md" />
     </div>
-    <div class="child_text Loader__text_error_page">
+    <div class="loading_text child_text">
       <div>Sign in is not available.</div>
       <div>Please try again later.</div>
     </div>


### PR DESCRIPTION
Fixed issues #2325, #2852 and #2820:
1. [Hydra - Mobile apps] [Audit Logs] "appVersion" is displayed null for the events #2820
Fix: Setting `appVersion` in cookie and then setting the value in `AuditEventMapper.fromHttpServletRequest(request)`.

2. Make oauth server login screens error toasts more visible #2325
Fix: Shifted the error message in the middle of the screen. Displaying error message to 5 second was already fixed in last release.

3. Text size of the loader page should be increased #2852
Fix: Removed `font-size` from `child_text ` class, as using `font-size` from `loading_text` class.