### PR TITLE
Study Builder : Fixed UI issue #2304 by changing the text when activation link is invalid/expired

### DIFF
--- a/study-builder/fdahpStudyDesigner/src/main/webapp/WEB-INF/view/errorPage.jsp
+++ b/study-builder/fdahpStudyDesigner/src/main/webapp/WEB-INF/view/errorPage.jsp
@@ -112,6 +112,13 @@ html, body {
     font-size: 100%;
     font-weight: 600; 
 }
+
+.width__50 {
+  width: 50%;
+}
+.mar_0_auto {
+  margin: 0 auto;
+}
 </style>
   </head>
   <body>
@@ -138,8 +145,8 @@ html, body {
         <span class="display-1 d-block">
           <img src="/studybuilder/images/icons/ErrorIcon.svg" alt="Page not found here" />
         </span>
-        <div class="invalidLink_text mt-4 mb-4">This link is no longer valid to be used. 
-                Please contact the system admin for assistance with your account or sign in if already registered.
+        <div class="invalidLink_text mt-4 mb-4 width__50  mar_0_auto">This link is no longer valid to be used. 
+        For any assistance needed with your account,<br> please contact the system admin.
         </div>
       </div>
 </div>

--- a/study-builder/fdahpStudyDesigner/src/main/webapp/WEB-INF/view/fdaAdminDashBoardPage.jsp
+++ b/study-builder/fdahpStudyDesigner/src/main/webapp/WEB-INF/view/fdaAdminDashBoardPage.jsp
@@ -55,7 +55,7 @@
   height: 13px;
   display: inline-block;
   position: relative;
-  bottom: -7px;
+  bottom: -8px;
   left: 0px;
   transition: 0.4s ease;
   margin-top: 8px;


### PR DESCRIPTION
Fixed issue #2304

Changed the errorPage text to `This link is no longer valid to be used. For any assistance needed with your account, please contact the system admin.` 