### PR TITLE
Fixed issues #2827 [Hydra][Audit logs] Event triggered in wrong scenario and #1248 

### DIFF
--- a/auth-server/oauth-scim-service/src/main/java/com/google/cloud/healthcare/fdamystudies/oauthscim/common/CookieHelper.java
+++ b/auth-server/oauth-scim-service/src/main/java/com/google/cloud/healthcare/fdamystudies/oauthscim/common/CookieHelper.java
@@ -47,7 +47,7 @@ public class CookieHelper {
     // An invalid character [32] (space) was present in the Cookie value
     cookieValue = StringUtils.defaultString(cookieValue);
     Cookie cookie = new Cookie(cookieName, URLEncoder.encode(cookieValue, "UTF-8"));
-    cookie.setMaxAge(600);
+    cookie.setMaxAge(1800);
     cookie.setSecure(appConfig.isSecureCookie());
     cookie.setHttpOnly(true);
     cookie.setPath("/");

--- a/auth-server/oauth-scim-service/src/main/java/com/google/cloud/healthcare/fdamystudies/oauthscim/controller/UserController.java
+++ b/auth-server/oauth-scim-service/src/main/java/com/google/cloud/healthcare/fdamystudies/oauthscim/controller/UserController.java
@@ -9,7 +9,6 @@
 package com.google.cloud.healthcare.fdamystudies.oauthscim.controller;
 
 import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimEvent.PASSWORD_HELP_REQUESTED;
-import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimEvent.PASSWORD_RESET_SUCCEEDED;
 import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimEvent.USER_SIGNOUT_FAILED;
 import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimEvent.USER_SIGNOUT_SUCCEEDED;
 
@@ -85,10 +84,6 @@ public class UserController {
     auditHelper.logEvent(PASSWORD_HELP_REQUESTED, auditRequest);
     ResetPasswordResponse resetPasswordResponse =
         userService.resetPassword(resetPasswordRequest, auditRequest, appName);
-
-    if (resetPasswordResponse.getHttpStatusCode() == HttpStatus.OK.value()) {
-      auditHelper.logEvent(PASSWORD_RESET_SUCCEEDED, auditRequest);
-    }
 
     logger.exit(String.format(STATUS_LOG, resetPasswordResponse.getHttpStatusCode()));
     return ResponseEntity.status(resetPasswordResponse.getHttpStatusCode())

--- a/auth-server/oauth-scim-service/src/main/java/com/google/cloud/healthcare/fdamystudies/oauthscim/service/UserServiceImpl.java
+++ b/auth-server/oauth-scim-service/src/main/java/com/google/cloud/healthcare/fdamystudies/oauthscim/service/UserServiceImpl.java
@@ -35,6 +35,7 @@ import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScim
 import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimEvent.PASSWORD_RESET_EMAIL_FAILED_FOR_LOCKED_ACCOUNT;
 import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimEvent.PASSWORD_RESET_EMAIL_SENT_FOR_LOCKED_ACCOUNT;
 import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimEvent.PASSWORD_RESET_FAILED;
+import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimEvent.PASSWORD_RESET_SUCCEEDED;
 import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimEvent.SIGNIN_FAILED_EXPIRED_PASSWORD;
 import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimEvent.SIGNIN_FAILED_EXPIRED_TEMPORARY_PASSWORD;
 import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimEvent.SIGNIN_FAILED_INVALID_PASSWORD;
@@ -323,10 +324,15 @@ public class UserServiceImpl implements UserService {
     userInfo.remove(ACCOUNT_LOCK_EMAIL_TIMESTAMP);
     userInfo.remove(ACCOUNT_LOCKED_PASSWORD);
     userInfo.put(LOGIN_ATTEMPTS, 0);
+    if (userEntity.getStatus() == UserAccountStatus.PASSWORD_RESET.getStatus()) {
+      auditHelper.logEvent(PASSWORD_RESET_SUCCEEDED, auditRequest);
+    } else {
+      auditHelper.logEvent(PASSWORD_CHANGE_SUCCEEDED, auditRequest);
+    }
+
     userEntity.setStatus(UserAccountStatus.ACTIVE.getStatus());
     userEntity.setUserInfo(userInfo);
     repository.saveAndFlush(userEntity);
-    auditHelper.logEvent(PASSWORD_CHANGE_SUCCEEDED, auditRequest);
     logger.exit("Your password has been updated successfully!");
     return new ChangePasswordResponse(MessageCode.CHANGE_PASSWORD_SUCCESS);
   }

--- a/auth-server/oauth-scim-service/src/test/java/com/google/cloud/healthcare/fdamystudies/oauthscim/controller/UserControllerTest.java
+++ b/auth-server/oauth-scim-service/src/test/java/com/google/cloud/healthcare/fdamystudies/oauthscim/controller/UserControllerTest.java
@@ -32,7 +32,6 @@ import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScim
 import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimEvent.PASSWORD_HELP_EMAIL_SENT;
 import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimEvent.PASSWORD_HELP_REQUESTED;
 import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimEvent.PASSWORD_HELP_REQUESTED_FOR_UNREGISTERED_USERNAME;
-import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimEvent.PASSWORD_RESET_SUCCEEDED;
 import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimEvent.USER_SIGNOUT_SUCCEEDED;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertFalse;
@@ -474,10 +473,6 @@ public class UserControllerTest extends BaseMockIT {
   @Test
   public void shouldChangeThePassword()
       throws MalformedURLException, JsonProcessingException, Exception {
-    // set the status to PASSWORD_RESET(3)
-    userEntity.setStatus(UserAccountStatus.PASSWORD_RESET.getStatus());
-    userEntity = repository.saveAndFlush(userEntity);
-
     // Step-1 Call PUT method to change the password
     HttpHeaders headers = getCommonHeaders();
     headers.add("Authorization", VALID_BEARER_TOKEN);
@@ -735,9 +730,8 @@ public class UserControllerTest extends BaseMockIT {
 
     Map<String, AuditLogEventRequest> auditEventMap = new HashedMap<>();
     auditEventMap.put(PASSWORD_HELP_REQUESTED.getEventCode(), auditRequest);
-    auditEventMap.put(PASSWORD_RESET_SUCCEEDED.getEventCode(), auditRequest);
 
-    verifyAuditEventCall(auditEventMap, PASSWORD_HELP_REQUESTED, PASSWORD_RESET_SUCCEEDED);
+    verifyAuditEventCall(auditEventMap, PASSWORD_HELP_REQUESTED);
   }
 
   @Test


### PR DESCRIPTION
1) Fixed issue #2827 [Hydra][Audit logs] Event triggered in wrong scenario
- Moved `PASSWORD_RESET_SUCCEEDED` event from password_reset API to password_change API.
- Logging this event after validating users account status, when user completes password reset process.
- Fixed test case failure.

2) Fixed issue #1248 Sign in not available page is continuously causing issue for sign in
Fix: Since cookie age was 10 minutes, so data in cookie was getting null after 10 minutes and app was redirecting to error page.
Increased the cookie age to 30 minutes.
