### PR TITLE
Fixed issues #1150 and #2421 [oauth server]  Continuous loading animator and fails to navigate to app when internet is disrupted during sign in

### DIFF
--- a/auth-server/oauth-scim-service/src/main/resources/static/js/autoLogin.js
+++ b/auth-server/oauth-scim-service/src/main/resources/static/js/autoLogin.js
@@ -7,7 +7,7 @@
  */
 
 window.onload = function() {
-  window.setTimeout(function() {
+  window.setInterval(function() {
     document.autoSignInForm.submit();
-  }, 2000);
+  }, 500);
 };

--- a/auth-server/oauth-scim-service/src/main/resources/static/js/consent.js
+++ b/auth-server/oauth-scim-service/src/main/resources/static/js/consent.js
@@ -7,7 +7,7 @@
  */
 
 window.onload = function() {
-  window.setTimeout(function() {
+  window.setInterval(function() {
     document.consentForm.submit();
-  }, 2000);
+  }, 500);
 };


### PR DESCRIPTION
Fixed issues:

1. [Android] Continuous loading animator and fails to navigate to app when internet is disrupted during sign in #1150
2. Mobile app sign-in hangs indefinitely #2421
Fix: Reduced the wait time and used `setInterval `function instead of `setTimeout `, which will keep on trying after specified interval, if there is any network issue happened in between.