### PR TITLE
Fixed issue #2922 [PM] Adjust the space between the icon and the text 

### DIFF
--- a/auth-server/oauth-scim-service/src/main/resources/templates/error.html
+++ b/auth-server/oauth-scim-service/src/main/resources/templates/error.html
@@ -33,15 +33,22 @@
     font-family: Muli,sans-serif !important;
     font-weight: 600 !important;
     text-align: center !important;
-    margin-top: 100% !important;
    }
 }
+
 .child_text { 
   color: #353a3e !important;
   font-family: Muli,sans-serif !important;
   font-weight: 600 !important;
   text-align: center !important;
-  margin-top: 100% !important;
+}
+
+.loading_error_text {
+  color: var(--space-gray);
+  font-size: 14px;
+  font-family: Muli, sans-serif;
+  font-weight: 600;
+  text-align: center;
 }
 </style>
 
@@ -51,7 +58,7 @@
     <div class="width__110">
       <img th:src="@{/images/ErrorIcon.svg}" alt="error image " class="mb-md" />
     </div>
-    <div class="loading_text child_text">
+    <div class="loading_error_text child_text">
       <div>Sign in is not available.</div>
       <div>Please try again later.</div>
     </div>


### PR DESCRIPTION
- Fixed issue #2922 [PM] Adjust the space between the icon and the text 
- Removed `margin-top` from css text class for error page to remove the extra space between error image and text.