### PR TITLE
[Participant Enroll Datastore] Changed HTTP status code for /validateEnrollmentToken endpoint for token already used

### DIFF
--- a/participant-datastore/enroll-mgmt-module/enroll-mgmt/src/main/java/com/google/cloud/healthcare/fdamystudies/controller/EnrollmentTokenController.java
+++ b/participant-datastore/enroll-mgmt-module/enroll-mgmt/src/main/java/com/google/cloud/healthcare/fdamystudies/controller/EnrollmentTokenController.java
@@ -87,7 +87,7 @@ public class EnrollmentTokenController {
       if (enrollmentTokenfService.hasParticipant(
           enrollmentBean.getStudyId(), enrollmentBean.getToken())) {
         ErrorResponseUtil.getFailureResponse(
-            ErrorResponseUtil.ErrorCodes.STATUS_103.getValue(),
+            ErrorResponseUtil.ErrorCodes.STATUS_102.getValue(),
             ErrorResponseUtil.ErrorCodes.INVALID_INPUT.getValue(),
             ErrorResponseUtil.ErrorCodes.TOKEN_ALREADY_USE.getValue(),
             response);

--- a/participant-datastore/enroll-mgmt-module/enroll-mgmt/src/test/java/com/google/cloud/healthcare/fdamystudies/controller/tests/EnrollmentTokenControllerTest.java
+++ b/participant-datastore/enroll-mgmt-module/enroll-mgmt/src/test/java/com/google/cloud/healthcare/fdamystudies/controller/tests/EnrollmentTokenControllerTest.java
@@ -165,7 +165,7 @@ public class EnrollmentTokenControllerTest extends BaseMockIT {
   }
 
   @Test
-  public void validateEnrollmentTokenForbidden() throws Exception {
+  public void validateEnrollmentTokenAlreadyUsedBadRequest() throws Exception {
     HttpHeaders headers = TestUtils.getCommonHeaders();
     headers.add(Constants.USER_ID_HEADER, Constants.VALID_USER_ID);
     headers.add("Authorization", VALID_BEARER_TOKEN);
@@ -192,7 +192,7 @@ public class EnrollmentTokenControllerTest extends BaseMockIT {
                 .content(requestJson)
                 .contextPath(getContextPath()))
         .andDo(print())
-        .andExpect(status().isForbidden());
+        .andExpect(status().isBadRequest());
 
     verifyTokenIntrospectRequest(2);
   }


### PR DESCRIPTION
Changed HTTP status code for /validateEnrollmentToken endpoint for token already used. Issue #2923 fix.