### PR TITLE
Participant Manager Datastore: Fixed issue #2423

### DIFF
--- a/common-modules/common-service/src/main/java/com/google/cloud/healthcare/fdamystudies/repository/ParticipantEnrollmentHistoryRepository.java
+++ b/common-modules/common-service/src/main/java/com/google/cloud/healthcare/fdamystudies/repository/ParticipantEnrollmentHistoryRepository.java
@@ -65,8 +65,7 @@ public interface ParticipantEnrollmentHistoryRepository
               + "withdrawal_timestamp IS NULL AND user_details_id =:userDetailsId",
       nativeQuery = true)
   public void updateWithdrawalDateAndStatusForDeactivatedUser(String userDetailsId, String status);
-  
-  
+
   @Query(
       value =
           "SELECT peh.status "
@@ -75,4 +74,12 @@ public interface ParticipantEnrollmentHistoryRepository
               + "ORDER BY peh.created_time DESC LIMIT 1",
       nativeQuery = true)
   public String findBySiteIdAndParticipantRegistryId(String siteId, String participantRegistryId);
+
+  @Query(
+      value =
+          "SELECT peh.status FROM participant_enrollment_history peh WHERE study_info_id=:studyId AND "
+              + "participant_registry_site_id=:participantRegistrySiteId ORDER BY created_time DESC LIMIT 1",
+      nativeQuery = true)
+  public String findByStudyIdAndParticipantRegistrySiteId(
+      String studyId, String participantRegistrySiteId);
 }

--- a/common-modules/common-service/src/main/java/com/google/cloud/healthcare/fdamystudies/repository/StudyRepository.java
+++ b/common-modules/common-service/src/main/java/com/google/cloud/healthcare/fdamystudies/repository/StudyRepository.java
@@ -116,7 +116,7 @@ public interface StudyRepository extends JpaRepository<StudyEntity, String> {
               + "loc.name AS locationName, loc.custom_id AS locationCustomId, "
               + "prs.invitation_time AS invitedDate, prs.id AS participantId, stu.type AS studyType "
               + "FROM participant_registry_site prs "
-              + "LEFT JOIN participant_study_info psi ON prs.id=psi.participant_registry_site_id AND psi.status NOT IN (:excludeParticipantStudyStatus) "
+              + "LEFT JOIN participant_study_info psi ON prs.id=psi.participant_registry_site_id  "
               + "LEFT JOIN study_info stu ON psi.study_info_id = stu.id  "
               + "LEFT JOIN sites si ON si.id=prs.site_id "
               + "LEFT JOIN locations loc ON loc.id=si.location_id "
@@ -135,12 +135,7 @@ public interface StudyRepository extends JpaRepository<StudyEntity, String> {
               + "LIMIT :limit OFFSET :offset",
       nativeQuery = true)
   public List<StudyParticipantDetails> getStudyParticipantDetailsForOpenStudy(
-      String studyId,
-      String[] excludeParticipantStudyStatus,
-      Integer limit,
-      Integer offset,
-      String orderByCondition,
-      String searchTerm);
+      String studyId, Integer limit, Integer offset, String orderByCondition, String searchTerm);
 
   @Query(
       value =

--- a/participant-manager-datastore/participant-manager-service/src/main/java/com/google/cloud/healthcare/fdamystudies/mapper/ParticipantMapper.java
+++ b/participant-manager-datastore/participant-manager-service/src/main/java/com/google/cloud/healthcare/fdamystudies/mapper/ParticipantMapper.java
@@ -60,8 +60,6 @@ public final class ParticipantMapper {
 
     String enrollmentDate = DateTimeUtils.format(studyParticipantDetail.getEnrolledDate());
     participantDetail.setEnrollmentDate(StringUtils.defaultIfEmpty(enrollmentDate, NOT_APPLICABLE));
-    participantDetail.setEnrollmentStatus(
-        EnrollmentStatus.getDisplayValue(studyParticipantDetail.getEnrolledStatus()));
 
     return participantDetail;
   }

--- a/participant-manager-datastore/participant-manager-service/src/main/java/com/google/cloud/healthcare/fdamystudies/service/StudyServiceImpl.java
+++ b/participant-manager-datastore/participant-manager-service/src/main/java/com/google/cloud/healthcare/fdamystudies/service/StudyServiceImpl.java
@@ -17,6 +17,7 @@ import com.google.cloud.healthcare.fdamystudies.beans.ParticipantRegistryRespons
 import com.google.cloud.healthcare.fdamystudies.beans.StudyDetails;
 import com.google.cloud.healthcare.fdamystudies.beans.StudyResponse;
 import com.google.cloud.healthcare.fdamystudies.common.CommonConstants;
+import com.google.cloud.healthcare.fdamystudies.common.EnrollmentStatus;
 import com.google.cloud.healthcare.fdamystudies.common.ErrorCode;
 import com.google.cloud.healthcare.fdamystudies.common.MessageCode;
 import com.google.cloud.healthcare.fdamystudies.common.ParticipantManagerAuditLogHelper;
@@ -31,6 +32,7 @@ import com.google.cloud.healthcare.fdamystudies.model.StudyEntity;
 import com.google.cloud.healthcare.fdamystudies.model.StudyInfo;
 import com.google.cloud.healthcare.fdamystudies.model.StudyParticipantDetails;
 import com.google.cloud.healthcare.fdamystudies.model.UserRegAdminEntity;
+import com.google.cloud.healthcare.fdamystudies.repository.ParticipantEnrollmentHistoryRepository;
 import com.google.cloud.healthcare.fdamystudies.repository.ParticipantStudyRepository;
 import com.google.cloud.healthcare.fdamystudies.repository.SiteRepository;
 import com.google.cloud.healthcare.fdamystudies.repository.StudyRepository;
@@ -43,6 +45,7 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.ext.XLogger;
 import org.slf4j.ext.XLoggerFactory;
@@ -63,6 +66,8 @@ public class StudyServiceImpl implements StudyService {
   @Autowired private ParticipantManagerAuditLogHelper participantManagerHelper;
 
   @Autowired private UserRegAdminRepository userRegAdminRepository;
+
+  @Autowired private ParticipantEnrollmentHistoryRepository participantEnrollmentHistory;
 
   @Override
   @Transactional(readOnly = true)
@@ -306,7 +311,6 @@ public class StudyServiceImpl implements StudyService {
       studyParticipantDetails =
           studyRepository.getStudyParticipantDetailsForOpenStudy(
               studyAppDetails.getStudyId(),
-              excludeParticipantStudyStatus,
               limit,
               offset,
               orderByCondition,
@@ -335,7 +339,31 @@ public class StudyServiceImpl implements StudyService {
     for (StudyParticipantDetails participantDetails : studyParticipantDetails) {
       ParticipantDetail participantDetail =
           ParticipantMapper.fromParticipantStudy(participantDetails);
-      registryParticipants.add(participantDetail);
+
+      String status = null;
+      if (studyAppDetails.getStudyType().equalsIgnoreCase(OPEN_STUDY)) {
+        status =
+            participantEnrollmentHistory.findByStudyIdAndParticipantRegistrySiteId(
+                studyAppDetails.getStudyId(), participantDetails.getParticipantId());
+        if (StringUtils.isNotEmpty(status)
+            && EnrollmentStatus.WITHDRAWN.getStatus().equals(status)
+            && EnrollmentStatus.NOT_ELIGIBLE
+                .getStatus()
+                .equals(participantDetails.getEnrolledStatus())) {
+          participantDetail.setEnrollmentStatus(EnrollmentStatus.WITHDRAWN.getDisplayValue());
+        } else {
+          participantDetail.setEnrollmentStatus(
+              EnrollmentStatus.getDisplayValue(participantDetails.getEnrolledStatus()));
+        }
+      } else {
+        participantDetail.setEnrollmentStatus(
+            EnrollmentStatus.getDisplayValue(participantDetails.getEnrolledStatus()));
+      }
+
+      if (!ArrayUtils.contains(
+          excludeParticipantStudyStatus, participantDetail.getEnrollmentStatus())) {
+        registryParticipants.add(participantDetail);
+      }
     }
 
     participantRegistryDetail.setRegistryParticipants(registryParticipants);

--- a/participant-manager-datastore/participant-manager-service/src/test/java/com/google/cloud/healthcare/fdamystudies/controller/StudyControllerTest.java
+++ b/participant-manager-datastore/participant-manager-service/src/test/java/com/google/cloud/healthcare/fdamystudies/controller/StudyControllerTest.java
@@ -725,48 +725,6 @@ public class StudyControllerTest extends BaseMockIT {
   }
 
   @Test
-  public void shouldNotReturnRegisteredParticipantWithYetToJoinStudyStatus() throws Exception {
-    HttpHeaders headers = testDataHelper.newCommonHeaders();
-    headers.add(USER_ID_HEADER, userRegAdminEntity.getId());
-
-    locationEntity = testDataHelper.createLocation();
-    studyEntity.setType(OPEN_STUDY);
-    siteEntity.setLocation(locationEntity);
-    siteEntity.setTargetEnrollment(0);
-    siteEntity.setStudy(studyEntity);
-    participantRegistrySiteEntity.setEmail(TestConstants.EMAIL_VALUE);
-    participantRegistrySiteEntity.setOnboardingStatus(OnboardingStatus.ENROLLED.getCode());
-    participantStudyEntity.setStudy(studyEntity);
-    participantStudyEntity.setStatus(EnrollmentStatus.YET_TO_ENROLL.getStatus());
-    participantStudyEntity.setParticipantRegistrySite(participantRegistrySiteEntity);
-    testDataHelper.getParticipantStudyRepository().saveAndFlush(participantStudyEntity);
-
-    mockMvc
-        .perform(
-            get(ApiEndpoint.GET_STUDY_PARTICIPANT.getPath(), studyEntity.getId())
-                .headers(headers)
-                .queryParam(
-                    "excludeParticipantStudyStatus", EnrollmentStatus.YET_TO_ENROLL.getStatus())
-                .contextPath(getContextPath()))
-        .andDo(print())
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.participantRegistryDetail.studyId").value(studyEntity.getId()))
-        .andExpect(jsonPath("$.participantRegistryDetail.registryParticipants").isArray())
-        .andExpect(jsonPath("$.participantRegistryDetail.registryParticipants", hasSize(0)));
-
-    AuditLogEventRequest auditRequest = new AuditLogEventRequest();
-    auditRequest.setUserId(userRegAdminEntity.getId());
-    auditRequest.setStudyId(studyEntity.getId());
-    auditRequest.setAppId(appEntity.getId());
-
-    Map<String, AuditLogEventRequest> auditEventMap = new HashedMap<>();
-    auditEventMap.put(STUDY_PARTICIPANT_REGISTRY_VIEWED.getEventCode(), auditRequest);
-
-    verifyAuditEventCall(auditEventMap, STUDY_PARTICIPANT_REGISTRY_VIEWED);
-    verifyTokenIntrospectRequest();
-  }
-
-  @Test
   public void shouldReturnUserNotFoundForStudyParticipants() throws Exception {
     HttpHeaders headers = testDataHelper.newCommonHeaders();
     headers.add(USER_ID_HEADER, IdGenerator.id());


### PR DESCRIPTION
Fixed issue #2423: 

- Written a query in `ParticipantEnrollmentHistoryRepository` to get the enrollment status based on created_time DESC
- Added conditional check to send enrollment status as withdrawn when participant fails eligibility test post withdrawn for open study
- Removed shouldNotReturnRegisteredParticipantWithYetToJoinStudyStatus() test as this is not a valid scenario as per current requirement 