### PR TITLE
Fixed issue  Mobile app sign-in hangs indefinitely #2421

### DIFF
--- a/auth-server/oauth-scim-service/src/main/resources/static/js/autoLogin.js
+++ b/auth-server/oauth-scim-service/src/main/resources/static/js/autoLogin.js
@@ -7,7 +7,7 @@
  */
 
 window.onload = function() {
-  window.setInterval(function() {
+  window.setTimeout(function() {
     document.autoSignInForm.submit();
   }, 500);
 };

--- a/auth-server/oauth-scim-service/src/main/resources/static/js/consent.js
+++ b/auth-server/oauth-scim-service/src/main/resources/static/js/consent.js
@@ -7,7 +7,7 @@
  */
 
 window.onload = function() {
-  window.setInterval(function() {
+  window.setTimeout(function() {
     document.consentForm.submit();
   }, 500);
 };


### PR DESCRIPTION
Fixed issue  Mobile app sign-in hangs indefinitely #2421
Reverting `setInterval` to `setTimeout`, which is causing sign-in screen randomly only in chrome browser. 