### PR TITLE
Fix insecure superadmin user password salting

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -320,6 +320,7 @@ time, an initial superadmin account needs to be generated for each application.
 generates an initial superadmin account for Participant Manager.
 
 ```bash
+sudo apt-get install uuid-runtime -y
 ./scripts/create_participant_manager_superadmin.sh <prefix> <env> <email> <password>
 ```
 

--- a/deployment/scripts/create_participant_manager_superadmin.sh
+++ b/deployment/scripts/create_participant_manager_superadmin.sh
@@ -30,7 +30,7 @@ TMPFILE=$(mktemp)
 
 echo "USE \`oauth_server_hydra\`;" >> ${TMPFILE}
 
-SALT=`printf "%s" uuidgen | iconv -t utf-8 | openssl dgst -sha512 | sed 's/^.* //'`
+SALT=`printf "%s" $(uuidgen) | iconv -t utf-8 | openssl dgst -sha512 | sed 's/^.* //'`
 HASH=`printf "%s%s" $SALT $PWD | iconv -t utf-8 | openssl dgst -sha512 | sed 's/^.* //'`
 if [[ "$OSTYPE" == "darwin"* ]]; then
 DATE=`date -v +30d +"%F %T"`


### PR DESCRIPTION
The salt should be unique each time the script is run, but currently we are just `sha512`ing the string "uuidgen", rather than running the `uuidgen` command. 

Also updated the README to ensure the requisite linux packages are installed so that the `uuidgen` command is available on the system.

Before
```
$ date
Wed Jan 20 18:29:42 UTC 2021
$ echo $(printf "%s" uuidgen | iconv -t utf-8 | openssl dgst -sha512 | sed 's/^.* //')
8426a41fc2b96b96abfb3a6898427c227ff16d7d924a7bb2898795fda00e80888fcb698dacf1985fc4892c555b845a5f0ee1366db33d377c01d687e69ba39b95
$ date
Wed Jan 20 18:30:07 UTC 2021
$ echo $(printf "%s" uuidgen | iconv -t utf-8 | openssl dgst -sha512 | sed 's/^.* //')
8426a41fc2b96b96abfb3a6898427c227ff16d7d924a7bb2898795fda00e80888fcb698dacf1985fc4892c555b845a5f0ee1366db33d377c01d687e69ba39b95
```
After:
```
$ date
Wed Jan 20 18:30:19 UTC 2021
$ echo $(printf "%s" $(uuidgen) | iconv -t utf-8 | openssl dgst -sha512 | sed 's/^.* //')
e015cfd1d393530ab0bfaf353f018591d013ec6ccfb2a5a01812706a9f65d40827834056bd9027589206a2a7e1389926c94a32ae442fa3cae6235f8ff8d2a333
$ date
Wed Jan 20 18:30:29 UTC 2021
$ echo $(printf "%s" $(uuidgen) | iconv -t utf-8 | openssl dgst -sha512 | sed 's/^.* //')
0f9bce5262e10bcc6023913956af47bc0771c69f9f2ab464c67f2ce574573d8d8f2323d0c97b6b75bc5cdd5ffc5c27c3096ebf119e1295df77936eb3b1aa86dd
```