### PR TITLE
Enable smtp username/password authn when the username is not a valid …

### DIFF
--- a/study-builder/fdahpStudyDesigner/src/main/java/com/fdahpstudydesigner/util/EmailNotification.java
+++ b/study-builder/fdahpStudyDesigner/src/main/java/com/fdahpstudydesigner/util/EmailNotification.java
@@ -48,6 +48,7 @@ public class EmailNotification {
         toMail = toMail.trim();
         mail.setToemail(toMail.toLowerCase());
       }
+      mail.setFromEmailUsername(propMap.get("from.email.username"));
       mail.setFromEmailAddress(propMap.get("from.email.address"));
       mail.setFromEmailPassword(propMap.get("from.email.password"));
       mail.setSmtpHostname(propMap.get("smtp.hostname"));
@@ -89,6 +90,7 @@ public class EmailNotification {
         mail.setToemail(StringUtils.join(toMailListNew, ','));
       }
       mail.setFromEmailAddress(propMap.get("from.email.address"));
+      mail.setFromEmailUsername(propMap.get("from.email.username"));
       mail.setFromEmailPassword(propMap.get("from.email.password"));
       mail.setSmtpHostname(propMap.get("smtp.hostname"));
       mail.setSmtpPortvalue(propMap.get("smtp.portvalue"));
@@ -126,6 +128,7 @@ public class EmailNotification {
         toMail = toMail.trim();
         mail.setToemail(toMail.toLowerCase());
       }
+      mail.setFromEmailUsername(propMap.get("from.email.username"));
       mail.setFromEmailAddress(propMap.get("from.email.address"));
       mail.setFromEmailPassword(propMap.get("from.email.password"));
       mail.setSmtpHostname(propMap.get("smtp.hostname"));

--- a/study-builder/fdahpStudyDesigner/src/main/java/com/fdahpstudydesigner/util/Mail.java
+++ b/study-builder/fdahpStudyDesigner/src/main/java/com/fdahpstudydesigner/util/Mail.java
@@ -58,6 +58,7 @@ public class Mail {
   private String ccEmail;
   private String fromEmailAddress = "";
   private String fromEmailName = "";
+  private String fromEmailUsername = "";
   private String fromEmailPassword;
   private String messageBody;
   private String smtpHostname = "";
@@ -95,6 +96,10 @@ public class Mail {
 
   public String getFromEmailName() {
     return fromEmailName;
+  }
+
+  public String getFromEmailUsername() {
+    return fromEmailUsername;
   }
 
   public String getFromEmailPassword() {
@@ -151,14 +156,14 @@ public class Mail {
     logger.info("Mail.sendemail() :: Starts");
     boolean sentMail = false;
     try {
-      final String username = this.getFromEmailAddress();
+      final String username = this.getFromEmailUsername();
       final String password = this.getFromEmailPassword();
       Properties props = makeProperties(useIpWhitelist);
       Session session =
           useIpWhitelist ? makeSession(props) : makeSession(props, username, password);
 
       Message message = new MimeMessage(session);
-      message.setFrom(new InternetAddress(username));
+      message.setFrom(new InternetAddress(this.getFromEmailAddress()));
       if (StringUtils.isNotBlank(this.getToemail())) {
         if (this.getToemail().indexOf(',') != -1) {
           message.setRecipients(
@@ -201,7 +206,7 @@ public class Mail {
     Multipart multipart = null;
 
     try {
-      final String username = this.getFromEmailAddress();
+      final String username = this.getFromEmailUsername();
       final String password = this.getFromEmailPassword();
       Properties props = makeProperties(useIpWhitelist);
       Session session =
@@ -223,7 +228,7 @@ public class Mail {
         message.setRecipients(Message.RecipientType.BCC, InternetAddress.parse(this.getBccEmail()));
       }
       message.setSubject(this.subject);
-      message.setFrom(new InternetAddress(username));
+      message.setFrom(new InternetAddress(this.getFromEmailAddress()));
 
       // Create the message part
       messageBodyPart = new MimeBodyPart();
@@ -306,6 +311,15 @@ public class Mail {
 
   public void setFromEmailName(String fromEmailName) {
     this.fromEmailName = fromEmailName;
+  }
+
+  public void setFromEmailUsername(String fromEmailUsername) {
+
+    if (!fromEmailUsername.equals("")) {
+      this.fromEmailUsername = fromEmailUsername;
+    } else {
+      this.fromEmailUsername= fromEmailAddress;
+    }
   }
 
   public void setFromEmailPassword(String fromEmailPassword) {

--- a/study-builder/fdahpStudyDesigner/src/main/resources/application.properties
+++ b/study-builder/fdahpStudyDesigner/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 # Email Configuration local
 from.email.address=${FROM_EMAIL_ADDRESS}
 # Unused with IP whitelist.
+from.email.username=${FROM_EMAIL_USERNAME}
 from.email.password=${FROM_EMAIL_PASSWORD}
 smtp.hostname=${SMTP_HOSTNAME}
 smtp.portvalue=465

--- a/study-builder/tf-deployment.yaml
+++ b/study-builder/tf-deployment.yaml
@@ -48,7 +48,12 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: email-credentials
-                  key: email_address
+                  key: from_email_address
+            - name: FROM_EMAIL_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: email-credentials
+                  key: email_address                  
             - name: FROM_EMAIL_PASSWORD
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
…email address

For example, when using AWS SES as the SMTP server, you need to log in with a username that is a 20 character string, e.g. `AKIAZZZZZZZZZZZZZZZZ`. If this value is set to the `email-credentials.email_address` secrets (in kubernetes), the participant manager can send emails no problem, but the study-builder throws an 'invalid email' error. If the `from_email_address` secret is used instead, an authentication error is thrown.
