### PR TITLE
Participant Manager Datastore: Fixed issue #2999 #3000 #2989

### DIFF
--- a/auth-server/oauth-scim-service/src/main/java/com/google/cloud/healthcare/fdamystudies/oauthscim/controller/UserController.java
+++ b/auth-server/oauth-scim-service/src/main/java/com/google/cloud/healthcare/fdamystudies/oauthscim/controller/UserController.java
@@ -103,6 +103,7 @@ public class UserController {
     AuditLogEventRequest auditRequest = AuditEventMapper.fromHttpServletRequest(request);
 
     userRequest.setUserId(userId);
+    auditRequest.setUserId(userId);
 
     ChangePasswordResponse userResponse = userService.changePassword(userRequest, auditRequest);
 

--- a/participant-manager-datastore/participant-manager-service/src/main/java/com/google/cloud/healthcare/fdamystudies/mapper/ParticipantMapper.java
+++ b/participant-manager-datastore/participant-manager-service/src/main/java/com/google/cloud/healthcare/fdamystudies/mapper/ParticipantMapper.java
@@ -195,8 +195,14 @@ public final class ParticipantMapper {
     participantDetail.setOnboardingStatus(status);
 
     ParticipantStudyEntity participantStudy = participantRegistry.getParticipantStudies().get(0);
-    participantDetail.setEnrollmentStatus(
-        EnrollmentStatus.getDisplayValue(participantStudy.getStatus()));
+
+    if (participantRegistry.getStudy().getType().equals(CommonConstants.OPEN_STUDY)
+        && !EnrollmentStatus.ENROLLED.getStatus().equals(participantStudy.getStatus())) {
+      participantDetail.setEnrollmentStatus(EnrollmentStatus.WITHDRAWN.getDisplayValue());
+    } else {
+      participantDetail.setEnrollmentStatus(
+          EnrollmentStatus.getDisplayValue(participantStudy.getStatus()));
+    }
 
     String enrolledDate = DateTimeUtils.format(participantStudy.getEnrolledDate());
     participantDetail.setEnrollmentDate(StringUtils.defaultIfEmpty(enrolledDate, NOT_APPLICABLE));

--- a/participant-manager-datastore/participant-manager-service/src/main/java/com/google/cloud/healthcare/fdamystudies/service/StudyServiceImpl.java
+++ b/participant-manager-datastore/participant-manager-service/src/main/java/com/google/cloud/healthcare/fdamystudies/service/StudyServiceImpl.java
@@ -347,9 +347,12 @@ public class StudyServiceImpl implements StudyService {
                 studyAppDetails.getStudyId(), participantDetails.getParticipantId());
         if (StringUtils.isNotEmpty(status)
             && EnrollmentStatus.WITHDRAWN.getStatus().equals(status)
-            && EnrollmentStatus.NOT_ELIGIBLE
-                .getStatus()
-                .equals(participantDetails.getEnrolledStatus())) {
+            && (EnrollmentStatus.NOT_ELIGIBLE
+                    .getStatus()
+                    .equals(participantDetails.getEnrolledStatus())
+                || EnrollmentStatus.YET_TO_ENROLL
+                    .getStatus()
+                    .equals(participantDetails.getEnrolledStatus()))) {
           participantDetail.setEnrollmentStatus(EnrollmentStatus.WITHDRAWN.getDisplayValue());
         } else {
           participantDetail.setEnrollmentStatus(


### PR DESCRIPTION
Fixed issue #2999 #3000: Added conditional check to send enrollment status as `withdrawn `when participant's enrollment status is `yetToEnroll ` or  `notEligible ` post withdrawn in participant details API
 #2989: set  `userId ` in  `auditRequest ` object