### PR TITLE
Fixed issue #2882 [Hydra] Account lock functionality is failed in Some scenario

### DIFF
--- a/auth-server/oauth-scim-service/src/main/java/com/google/cloud/healthcare/fdamystudies/oauthscim/controller/CallbackController.java
+++ b/auth-server/oauth-scim-service/src/main/java/com/google/cloud/healthcare/fdamystudies/oauthscim/controller/CallbackController.java
@@ -9,7 +9,6 @@
 package com.google.cloud.healthcare.fdamystudies.oauthscim.controller;
 
 import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimConstants.ACCOUNT_STATUS_COOKIE;
-import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimConstants.APP_VERSION_COOKIE;
 import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimConstants.ERROR_VIEW_NAME;
 import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimConstants.MOBILE_PLATFORM_COOKIE;
 import static com.google.cloud.healthcare.fdamystudies.oauthscim.common.AuthScimConstants.SOURCE_COOKIE;
@@ -83,11 +82,12 @@ public class CallbackController {
     String accountStatus = cookieHelper.getCookieValue(request, ACCOUNT_STATUS_COOKIE);
     String source = cookieHelper.getCookieValue(request, SOURCE_COOKIE);
     String callbackUrl = redirectConfig.getCallbackUrl(mobilePlatform, source);
-    String appVersion = cookieHelper.getCookieValue(request, APP_VERSION_COOKIE);
 
     String redirectUrl = null;
     if (StringUtils.equals(
-        accountStatus, String.valueOf(UserAccountStatus.PASSWORD_RESET.getStatus()))) {
+            accountStatus, String.valueOf(UserAccountStatus.PASSWORD_RESET.getStatus()))
+        || StringUtils.equals(
+            accountStatus, String.valueOf(UserAccountStatus.ACCOUNT_LOCKED.getStatus()))) {
       Optional<UserEntity> optUserEntity = userService.findByUserId(userId);
       if (optUserEntity.isPresent()) {
         UserEntity user = optUserEntity.get();

--- a/auth-server/oauth-scim-service/src/main/resources/templates/login.html
+++ b/auth-server/oauth-scim-service/src/main/resources/templates/login.html
@@ -102,7 +102,7 @@
                           class="col-md-12 col-xs-12 pr-none pl-none text-left">
                           <a class="blue__link forgot__pwd mobile"
                             th:href="${forgot_password_link}">Forgot
-                            Password?</a>
+                            password?</a>
                         </div>
                       </div>
                       <div
@@ -116,7 +116,7 @@
                           <a class="blue__link forgot__pwd desktop"
                             style = "margin-left: 65% !important;"
                             th:href="${forgot_password_link}">Forgot
-                            Password?</a> <span
+                            password?</a> <span
                             class="mobile sign__up forgot__pwd costom_ml"
                             th:if="${mobileApp}">New user? <a
                             th:href="${signup_link}" class="blue__link">Sign
@@ -146,7 +146,7 @@
       <ul>
         <li th:if="${!mobileApp}"><a th:href="${about_link}">About</a></li>
         <li th:if="${!mobileApp}"><a th:href="${terms_link}">Terms
-            of Service</a></li>
+            of service</a></li>
         <li th:if="${mobileApp}"><a th:href="${terms_link}">Terms</a></li>
         <li th:if="${mobileApp}"><a
           th:href="${privacy_policy_link}">Privacy Policy</a></li>

--- a/participant-manager-datastore/participant-manager-service/src/test/java/com/google/cloud/healthcare/fdamystudies/controller/SiteControllerTest.java
+++ b/participant-manager-datastore/participant-manager-service/src/test/java/com/google/cloud/healthcare/fdamystudies/controller/SiteControllerTest.java
@@ -106,7 +106,6 @@ import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
-import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.util.ResourceUtils;
@@ -123,7 +122,6 @@ public class SiteControllerTest extends BaseMockIT {
   @Autowired private SiteRepository siteRepository;
   @Autowired private ParticipantStudyRepository participantStudyRepository;
   @Autowired private ParticipantRegistrySiteRepository participantRegistrySiteRepository;
-  @Autowired private JavaMailSender emailSender;
   @Autowired private StudyConsentRepository studyConsentRepository;
 
   private UserRegAdminEntity userRegAdminEntity;
@@ -145,9 +143,9 @@ public class SiteControllerTest extends BaseMockIT {
 
   @BeforeEach
   public void setUp() {
-    locationEntity = testDataHelper.createLocation();
+    locationEntity = testDataHelper.createSiteLocation();
     userRegAdminEntity = testDataHelper.createUserRegAdminEntity();
-    appEntity = testDataHelper.createAppEntity(userRegAdminEntity);
+    appEntity = testDataHelper.createAppEntityForSiteControllerTest(userRegAdminEntity);
     studyEntity = testDataHelper.createStudyEntity(userRegAdminEntity, appEntity);
     siteEntity = testDataHelper.createSiteEntity(studyEntity, userRegAdminEntity, appEntity);
     participantRegistrySiteEntity =

--- a/participant-manager-datastore/participant-manager-service/src/test/java/com/google/cloud/healthcare/fdamystudies/helper/TestDataHelper.java
+++ b/participant-manager-datastore/participant-manager-service/src/test/java/com/google/cloud/healthcare/fdamystudies/helper/TestDataHelper.java
@@ -213,6 +213,46 @@ public class TestDataHelper {
     return locationEntity;
   }
 
+  public LocationEntity createSiteLocation() {
+    LocationEntity locationEntity = newSiteLocationEntity();
+    SiteEntity siteEntity = newSiteControllerEntity();
+    locationEntity.addSiteEntity(siteEntity);
+    return locationRepository.saveAndFlush(locationEntity);
+  }
+
+  public LocationEntity newSiteLocationEntity() {
+    LocationEntity locationEntity = new LocationEntity();
+    locationEntity.setCustomId("Location@#$03");
+    locationEntity.setDescription("California, CA");
+    locationEntity.setName(RandomStringUtils.randomAlphanumeric(8));
+    locationEntity.setStatus(ACTIVE_STATUS);
+    locationEntity.setIsDefault(NO);
+    return locationEntity;
+  }
+
+  public SiteEntity newSiteControllerEntity() {
+    SiteEntity siteEntity = new SiteEntity();
+    siteEntity.setName("siteControllerName");
+    siteEntity.setStatus(ACTIVE_STATUS);
+    return siteEntity;
+  }
+
+  public AppEntity createAppEntityForSiteControllerTest(UserRegAdminEntity userEntity) {
+    AppEntity appEntity = appEntity();
+    AppPermissionEntity appPermissionEntity = new AppPermissionEntity();
+    appPermissionEntity.setEdit(Permission.EDIT);
+    appPermissionEntity.setUrAdminUser(userEntity);
+    appEntity.addAppPermissionEntity(appPermissionEntity);
+    return appRepository.saveAndFlush(appEntity);
+  }
+
+  public AppEntity appEntity() {
+    AppEntity appEntity = new AppEntity();
+    appEntity.setAppId("MyStudies-Id-2");
+    appEntity.setAppName("MyStudies-2");
+    return appEntity;
+  }
+
   public UserRegAdminEntity createUserRegAdminEntity() {
     return userRegAdminRepository.saveAndFlush(newUserRegAdminEntity());
   }


### PR DESCRIPTION
- Fixed issue #2882 [Hydra] Account lock functionality is failed in Some scenario
- Issue: Mobile app is throwing error when user tries to reset password using temporary password.
- Fix.: `email` address was missing in deeplink URL. So added `ACCOUNT_LOCKED` validation in `CallbackController.java` file.

- Text changes in `login.html` file as per BA input.

- Modified `SiteControllerTest.java` file to fix build failure of Participant manager datastore.
