### PR TITLE
Deployment scripts update

### DIFF
--- a/auth-server/tf-deployment.yaml
+++ b/auth-server/tf-deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: auth-server
-          image: gcr.io/fda-mystudies-dev-apps/auth-server:latest
+          image: gcr.io/<PREFIX>-<ENV>-apps/auth-server:latest
           env:
             # DB ACCESS
             - name: DB_USER
@@ -158,7 +158,7 @@ spec:
         - name: cloudsql-proxy
           image: gcr.io/cloudsql-docker/gce-proxy:latest
           command: ["/cloud_sql_proxy",
-                    "-instances=fda-mystudies-dev-data:us-east1:mystudies=tcp:3306",
+                    "-instances=<PREFIX>-<ENV>-data:<LOCATION>:mystudies=tcp:3306",
                     "-credential_file=/secrets/gcloud_key/key.json"]
           volumeMounts:
           - name: gcloud-key-volume

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,379 +1,489 @@
-# Deploy FDA MyStudies using Terraform Engine and Terraform
+<!--
+ Copyright 2020 Google LLC
+ Use of this source code is governed by an MIT-style
+ license that can be found in the LICENSE file or at
+ https://opensource.org/licenses/MIT.
+-->
 
-This document provides instructions for deploying FDA MyStudies on Google Cloud
-in using infrastrucutre-as-code in approximately 1 hour. A video tutorial that
-walks the user through these steps is available upon request.
+## Deploying FDA MyStudies
+### Introduction
 
-The provided [template](./deployment.hcl) can be instantiated and used with
-[Terraform Engine](https://github.com/GoogleCloudPlatform/healthcare-data-protection-suite/tree/master/docs/tfengine)
-to generate Terraform configs that define and deploy the entire infrastructure.
+This guide provides instructions for semi-automated deployment of FDA MyStudies to Google Cloud. It is designed to be completed in just a few hours.
 
-The generated Terraform configs from the template deploys the FDA MyStudies
-infrastructure in a dedicated folder with remote Terraform state management and
-CICD pipelines enabled by default. The generated Terraform configs should be
-checked-in to a GitHub repository.
+This document explains how to integrate [Terraform’s](https://www.terraform.io/) open-source infrastructure-as-code with continuous integration and continuous deployment (CICD) for a reproducible and easy-to-maintain environment. [Kubernetes](https://kubernetes.io/) has been selected as the open-source container orchestration tool for its robust scaling and cluster management. All necessary Terraform templates, setup scripts and Kubernetes configuration files are included in the repository. This guide will explain what cloud services to enable, which configuration parameters to update and provide step-by-step instructions for each manual portion of the process.
 
-This Terraform deployment is an adaptation of Google Cloud's
-[HIPAA-aligned architecture](https://cloud.google.com/solutions/architecture-hipaa-aligned-project).
-This approach to project configuration and deployment is explained in the
-["Setting up a HIPAA-aligned project"](https://cloud.google.com/solutions/setting-up-a-hipaa-aligned-project)
+This approach to deployment is based on Google Cloud's
+[HIPAA-aligned architecture](https://cloud.google.com/solutions/architecture-hipaa-aligned-project), which is designed to simplify your compliance journey. You can learn more about this approach to compliance in the [*Setting up a HIPAA-aligned project*](https://cloud.google.com/solutions/setting-up-a-hipaa-aligned-project)
 solution guide.
 
-## Prerequisites
+### Deployment overview
 
-Follow
-[Prerequisites](https://github.com/GoogleCloudPlatform/healthcare-data-protection-suite/tree/templates-v0.4.0/docs/tfengine#prerequisites)
-and prepare to deploy FDA MyStudies platform infrastructure in a folder.
+Following this guide will result in your own unique instance of the FDA MyStudies platform. The resulting deployment will have the structure illustrated in [**Figure 1**](#figure-1-overall-architecture-of-the-semi-automated-deployment). Each functionally distinct aspect of the platform is deployed into its own cloud project to facilitate compartmentalization and robust access management. Each project and resource is named for its purpose, and has a `{PREFIX}-{ENV}` label, where `{PREFIX}` is a consistent name of your choice and `{ENV}` describes your environment (for example, `dev` or `prod`). The list of projects you will create for your deployment is as follows:
 
-In addition, [Create](https://support.google.com/a/answer/33343?hl=en) the
-following additional administrative
-[IAM](https://cloud.google.com/iam/docs/overview#concepts_related_identity)
-groups:
+Project | Name | Purpose
+---------|------------|---------------
+Devops | `{PREFIX}-{ENV}-devops` | This project executes the Terraform CICD pipeline that keeps your infrastructure aligned with the state defined in the [`deployment/terraform/`](/deployment/terraform/) directory of your GitHub repository
+Apps | `{PREFIX}-{ENV}-apps` | This project stores the container images for each of your FDA MyStudies applications, updates those images with CICD pipelines that monitor changes you make to the application directories of your GitHub repository, and administers the Kubernetes cluster that operates those images ([**Figure 2**](#figure-2-application-architecture) diagrams each the applications and how they related to their data sources)
+Data | `{PREFIX}-{ENV}-data` | This project contains the MySQL databases that support each of the FDA MyStudies applications, and the blob storage buckets that hold study resources and consent documents
+Firebase | `{PREFIX}-{ENV}-firebase` | This project contains the NoSQL database that stores the study response data
+Networks | `{PREFIX}-{ENV}-networks` | This project manages the network policies and firewalls 
+Secrets | `{PREFIX}-{ENV}-secrets` | This project manages the deployment’s secrets, such as client ids and client secrets
+Audit | `{PREFIX}-{ENV}-audit` | This project stores the audit logs for the FDA MyStudies platform and applications
 
-- {PREFIX}-bastion-accessors@{DOMAIN}: This group has permission to access the
-    bastion host which can then access the private Cloud SQL instance.
+This deployment configures the applications URLs as follows:
 
-Note: Consider including {ENV} in {PREFIX}.
+Application | URL | Notes
+--------------|-----------|-----------
+[Study builder](/study-builder/) | `studies.{PREFIX}-{ENV}.{DOMAIN}/study-builder` | This URL navigates an administrative user to the `Study builder` user interface
+[Study datastore](/study-datastore/) | `studies.{PREFIX}-{ENV}.{DOMAIN}/study-datastore` | This URL is for the `Study datastore` back-end service
+[Participant manager](/participant-manager/) | `participants.{PREFIX}-{ENV}.{DOMAIN}/participant-manager` | This URL navigates an administrative user to the `Participant manager` user interface
+[Participant manager datastore](/participant-manager-datastore/) | `participants.{PREFIX}-{ENV}.{DOMAIN}/participant-manager-datastore` | This URL is for the `Participant manager datastore` back-end service
+[Participant datastore](/participant-datastore/) | `participants.{PREFIX}-{ENV}.{DOMAIN}/participant-user-datastore`<br/>`participants.{PREFIX}-{ENV}.{DOMAIN}/participant-enroll-datastore`<br/>`participants.{PREFIX}-{ENV}.{DOMAIN}/participant-consent-datastore` | These URLs are for the `Participant datastore` back-end services
+[Response datastore](/response-datastore/) | `participants.{PREFIX}-{ENV}.{DOMAIN}/response-datastore` | This URL is for the `Response datastore` back-end service
+[Auth server](/auth-server/) | `participants.{PREFIX}-{ENV}.{DOMAIN}/auth-server` | This URL is for the administrative users and study participants to log into their respective applications
+[Hydra](/hydra/) | `participants.{PREFIX}-{ENV}.{DOMAIN}/oauth2` | This URL is used by the `Auth server` to complete OAuth 2.0 consent flows
 
-## Installation
+More information about the purpose of each application can be found in the [*Platform Overview*](/documentation/architecture.md) guide. Detailed information about configuration and operation of each application can be found in their [respective READMEs](/documentation/README.md).
 
-Follow the
-[installation instructions](https://github.com/GoogleCloudPlatform/healthcare-data-protection-suite/tree/master/docs/tfengine/#installation)
-to install the tfengine binary v0.4.0.
+#### Figure 1: Overall architecture of the semi-automated deployment
+![Architecture](/documentation/images/deployment-reference-architecture.svg "Architecture")
 
-## Layout of the generated Terraform configs
+#### Figure 2: Application architecture
+![Applications](/documentation/images/apps-reference-architecture.svg "Applications")
 
-```bash
-|- devops/: one time manual deployment to create projects to host Terraform state and CICD pipeline.
-|- cicd/: one time manual deployment to create CICD pipelines and configure permissions.
-|- audit/: audit project and resources (Log bucket, dataset and sinks).
-|- {PREFIX}-{ENV}-apps/: apps project and resources (GKE).
-|- {PREFIX}-{ENV}-data/: data project and resources (GCS buckets, CloudSQL instances).
-|- {PREFIX}-{ENV}-firebase/: firebase project and resources (firestores).
-|- {PREFIX}-{ENV}-networks/: networks project and resources (VPC, bastion host).
-|- {PREFIX}-{ENV}-secrets/: secrets project and resources (secrets).
-|- kubernetes/: manual kubernetes deployment after the GKE cluster has been created.
-```
+The deployment process takes the following approach:
+1. Create a copy of the FDA MyStudies repository that you will use for your deployment
+1. Create the `devops` cloud project that will be used to orchestrate your deployment
+1. Connect your cloned FDA MyStudies repository to your `devops` project and set up the CICD pipelines that will automate the rest of your deployment
+1. Provision the necessary cloud resources using your CICD pipelines
+1. Set up a second CICD pipeline that will automate creation of your application containers
+1. Create a Kubernetes cluster to run your application containers
+1. Create your initial user accounts and configure the required certificates, secrets, URLs, policies and network mesh
+1. Customize branding and text content as desired
+1. Create your first study
+1. Configure and deploy your mobile applications
 
-Each directory (devops/, cicd/, {PREFIX}-{ENV}-apps/, etc) represents one
-Terraform deployment. Each deployment will manage specific resources in you
-infrastructure.
+### Before you begin
 
-A deployment typically contains the following files:
+1. Familiarize yourself with:
+    -    [Terraform](https://www.terraform.io/) and [Terraform Engine](https://github.com/GoogleCloudPlatform/healthcare-data-protection-suite/tree/master/docs/tfengine)
+    -    [Kubernetes](https://kubernetes.io/) and [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl)
+    -    [CICD](https://en.wikipedia.org/wiki/CI/CD) and [Google Cloud Build](https://cloud.google.com/kubernetes-engine/docs/tutorials/gitops-cloud-build)
+    -    [IAM](https://en.wikipedia.org/wiki/Identity_management) and Google Cloud’s [resource hierarchy](https://cloud.google.com/resource-manager/docs/cloud-platform-resource-hierarchy)
+1. Understand how the Terraform config files and cloud resources are named and organized in the deployment:
+    -  `{PREFIX}` is a name you choose for your deployment that will be prepended to various directories, cloud resources and URLs (for example this could be ‘mystudies’)
+    -  `{ENV}` is a label you choose that will be appended to `{PREFIX}` in your directories and cloud resources (for example this could be ‘dev’, ‘test’ or ‘prod’)
+    - `{DOMAIN}` is the domain you will be using for your URLs (for example, ‘your_company_name.com’ or ‘your_medical_center.edu’)
+    - [`/deployment/deployment.hcl`](/deployment/deployment.hcl) is the file where you will specify top-level parameters for your deployment (for example, the values of `{PREFIX}`, `{ENV}` and `{DOMAIN}`)
+    - [`/deployment/mystudies.hcl`](/deployment/mystudies.hcl) is the file that represents the overall recipe for the deployment (you will uncomment various aspects of this recipe as your deployment progresses)
+    - The directories created in [`/deployment/terraform/`](/deployment/terraform/) by the `tfengine` command represent distinct cloud projects that the CICD pipeline monitors to create, update or destroy resources based on the changes you make to those directories
+    -  The other directories in the FDA MyStudies repository map to the various components of the platform and contain Terraform and Kubernetes configuration files, such as `tf-deployment.yaml` and `tf-service.yaml`, that support each component’s deployment
 
-- **main.tf**: This file defines the Terraform resources and modules to
-    manage.
+### Prepare the cloud platform
 
-- **variables.tf**: This file defines any input variables that the deployment
-    can take.
+1. Make sure you have access to a Google Cloud environment that contains an [organization resource](https://cloud.google.com/resource-manager/docs/creating-managing-organization#acquiring) (if you don’t have an organization resource, you can obtain one by [creating](https://support.google.com/a/answer/9983832) a Google Workspace and selecting a domain)
+1. Confirm the billing account that you will use has [quota](https://support.google.com/cloud/answer/6330231?hl=en) for 10 or more projects (newly created billing accounts may default to a 3-5 project quota)
+    - You can test how many projects your billing account can support by manually [creating projects](https://cloud.google.com/resource-manager/docs/creating-managing-projects) and [linking them](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project) to your billing account, if you are able to link 10 projects to your billing account then you can proceed, otherwise [request additional quota](https://support.google.com/code/contact/billing_quota_increase) (don’t forget to unlink the test projects from your billing account, otherwise your quota may be exhausted) 
+1. Use the [resource manager](https://console.cloud.google.com/cloud-resource-manager) to [create a folder](https://cloud.google.com/resource-manager/docs/creating-managing-folders) to deploy your FDA MyStudies infrastructure into, for example you could name this folder `{PREFIX}-{ENV}` (if you do not have the [`resourcemanager.folderAdmin`](https://cloud.google.com/resource-manager/docs/access-control-folders) role for your organization, you may need to ask your Google Cloud IT administrator to do this for you)
+1. Confirm you have access to a user account with the following Cloud IAM roles:
+    - `roles/resourcemanager.folderAdmin` for the folder you created
+    - `roles/resourcemanager.projectCreator` for the folder you created
+    - `roles/compute.xpnAdmin` for the folder you created
+    - `roles/billing.admin` for the billing account that you will use
+1. Use the [groups manager](https://console.cloud.google.com/identity/groups) to [create](https://support.google.com/a/answer/33343?hl=en) the following
+    administrative [IAM](https://cloud.google.com/iam/docs/overview#concepts_related_identity) groups that will be used during deployment:
 
-- **outputs.tf**: This file defines any outputs from this deployment. These
-    values can be used by other deployments.
+    Group name | Description
+    ------------------|----------------
+    `{PREFIX}-{ENV}-folder-admins@{DOMAIN}` | Members of this group have the [resourcemanager.folderAdmin](https://cloud.google.com/iam/docs/understanding-roles#resource-manager-roles) role for your deployment’s folder (for example, a deployment with prefix `mystudies`, environment `prod` and domain `example.com`, would require a group named `mystudies-prod-folder-admins@example.com`)
+    `{PREFIX}-{ENV}-devops-owners@{DOMAIN}` | Members of this group have owners access for the devops project, which is required to make changes to the CICD pipeline and Terraform state
+    `{PREFIX}-{ENV}-auditors@{DOMAIN}` | Members of this group have the [`iam.securityReviewer`](https://cloud.google.com/iam/docs/understanding-roles#iam-roles) role for your deployment’s folder, and the `bigquery.user` and `storage.objectViewer` roles for your audit log project
+    `{PREFIX}-{ENV}-cicd-viewers@{DOMAIN}` | Members of this group can view CICD results in Cloud Build, for example the results of the `terraform plan` presubmit and `terraform apply` postsubmit
+    `{PREFIX}-{ENV}-bastion-accessors@{DOMAIN}` | Members of this group have permission to access the [bastion host](https://cloud.google.com/solutions/connecting-securely#bastion) project, which provides access to the private Cloud SQL instance
+    `{PREFIX}-{ENV}-project-owners@{DOMAIN}` | Members of this group have owners access to each of the deployment’s projects
+1. Add the user account that you will be using for deployment to these groups (if it is not already a member)
 
-- **terraform.tfvars**: This file defines values for the input variables.
+### Set up your environment
 
-To see what resources each deployment provisions, check out the comments in both
-[mystudies.hcl](./mystudies.hcl) file and individual **main.tf** file.
-
-## CICD
-
-Deployments listed under `managed_modules` in the `cicd` recipe are configured
-to be deployed via CICD pipelines.
-
-The CICD service account can manage a subset of resources (e.g. APIs) within its
-own project (`devops` project). This allows users to have low risk changes made
-in the `devops` project deployed through the standard Cloud Build pipelines,
-without needing to apply it manually. Other changes in the `devops` project
-outside the approved set (APIs) will still need to be made manually.
-
-A common use case for this is when adding a new resource in a project that
-requires a new API to be enabled. You must add the API in both the resource's
-project as well as the `devops` project. With the feature above, the CICD can
-deploy both changes for you.
-
-## Deployment steps
-
-Note that the deployemnt steps involve editing the Terraform Engine config and
-regenerating the Terraform configs several times.
-
-### Preparation
-
-1. Authenticate as a super admin using `gcloud auth login [ACCOUNT]`.
-
-    WARNING: remember to run `gcloud auth revoke` to logout as a super admin.
-    Being logged in as a super admin beyond the initial setup is dangerous!
-
-1. Make a copy of [deployment.hcl](./deployment.hcl) and fill in instance
-    specific values, which includes:
-
-    - prefix
-    - env
-    - domain
-    - billing_account
-    - folder_id
-    - github.owner
-    - github.name
-    - ...
-
-    You can also change other field such as location of resources, etc to fit
-    your use case.
-
-1. Clone the remote GitHub repository locally which will be used to check in
-    your Terraform configs and save the local path to an environment variable
-    `GIT_ROOT`.
-
-    ```bash
-    export GIT_ROOT=/path/to/your/local/repo/fda-mystudies
+1. You can work in an existing environment, or you can configure a new environment by [creating](https://cloud.google.com/compute/docs/instances/create-start-instance) a VM instance in the Google Cloud project of your choice (for example, an `e2-medium` GCE VM with Debian GNU/Linux 10 and default settings)
+1. Confirm you have the following dependencies installed and added to your `$PATH`:
+    - [Install](https://cloud.google.com/sdk/docs/install) the Google Cloud command line tool `gcloud` (already installed if using a Google Compute Engine VM), for example:
+         ```bash
+         apt-get install google-cloud-sdk
+         ```
+    - [Install](https://cloud.google.com/storage/docs/gsutil_install) the Cloud Storage command line tool `gsutil` (already installed if using a Google Compute Engine VM)
+    - [Install](https://kubernetes.io/docs/tasks/tools/install-kubectl) the Kubernetes command line tool `kubectl`, for example:
+         ```bash
+         sudo apt-get update && sudo apt-get install -y apt-transport-https gnupg2 curl && \
+           curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add - && \
+           echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list && \
+           sudo apt-get update && \
+           sudo apt-get install -y kubectl
+         ```
+    - Install [Terraform 0.12.29](https://learn.hashicorp.com/tutorials/terraform/install-cli), for example:
+         ```shell
+         sudo apt-get install software-properties-common -y && \
+           curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add - && \
+           sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" && \
+           sudo apt-get update && sudo apt-get install terraform=0.12.29
+         ```
+    - Install [Terraform Engine](https://github.com/GoogleCloudPlatform/healthcare-data-protection-suite/tree/master/docs/tfengine#installation), for example:
+         ```shell
+         VERSION=v0.4.0 && \
+           sudo apt install wget -y && \
+           sudo wget -O /usr/local/bin/tfengine https://github.com/GoogleCloudPlatform/healthcare-data-protection-suite/releases/download/${VERSION}/tfengine_${VERSION}_linux-amd64 && \
+           sudo chmod +x /usr/local/bin/tfengine
+         ```
+    - Install [Git](https://github.com/git-guides/install-git), for example:
+         ```shell
+         sudo apt-get install git
+         ```
+1. [Duplicate](https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/duplicating-a-repository) the [FDA MyStudies repository](https://github.com/GoogleCloudPlatform/fda-mystudies), then clone it locally
+1. Update [`/deployment/deployment.hcl`](/deployment/deployment.hcl) with the values for your deployment
+1. Update [`/deployment/scripts/set_env_var.sh`](/deployment/scripts/set_env_var.sh) for your deployment, then use the script to set your environment variables, for example:
     ```
-
-1. Save the path to your copy of the deployment template and the path to the
-    `mystudies.hcl` solution template to environment variables for later easy
-    referencing.
-
-    ```bash
-    export ENGINE_CONFIG=/path/to/your/local/deployment.hcl
-    export MYSTUDIES_TEMPLATE=/path/to/your/local/mystudies.hcl
+    source set_env_var.sh    # executed from your /deployment/scripts directory
     ```
+1. Authenticate as a user with the permissions described above (this deployment assumes gcloud and Terraform commands are made as a user, rather than a service account)
+    - Login and update your [application default credentials](https://cloud.google.com/docs/authentication/production), for example you could run `gcloud auth login --update-adc` (when using a Google Compute Engine VM you must update the application default credentials, otherwise requests will continue to be made with its default service account)
+    - Remember to log your user account out once your deployment is complete
 
-### Step 1: Deploy Devops project and CICD manually
+### Create your devops project and configure CICD pipelines
 
-1. Execute the `tfengine` command to generate the configs. By default, CICD
-    will look for Terraform configs under the `terraform/` directory in the
-    GitHub repo, so set the `--output_path` to point to the `terraform/`
-    directory inside the local root of your GitHub repository.
-
-    Make sure in your first deployment in a new folder, `enable_gcs_backend` in
-    `$MYSTUDIES_TEMPLATE` is set to `false` or commented out.
-
-    ```bash
-    tfengine --config_path=$ENGINE_CONFIG --output_path=$GIT_ROOT/deployment/terraform
-    ```
-
-#### Devops Project
-
-1. Deploy the `devops/` folder first to create the `devops` project and
-    Terraform state bucket.
-
+1. Generate your Terraform configuration files
+    - Set the `enable_gcs_backend` flag in [`mystudies.hcl`](/deployment/mystudies.hcl) to `false`, for example:
+         ```bash
+         sed -e 's/enable_gcs_backend = true/enable_gcs_backend = false/g' \
+          -i.backup $GIT_ROOT/deployment/mystudies.hcl
+         ``` 
+    - Execute the `tfengine` command to generate the configs (by default, CICD
+    will look for Terraform configs under the `deployment/terraform/` directory in the
+    GitHub repo, so set the `--output_path` to point to the `deployment/terraform/`
+    directory inside the local root of your GitHub repository), for example:
+         ```bash
+         tfengine --config_path=$ENGINE_CONFIG --output_path=$GIT_ROOT/deployment/terraform
+         ```
+1. Use Terraform to create the `{PREFIX}-{ENV}-devops` project and Terraform state bucket (if this step fails, confirm you have updated your application default credentials and that the required version of Terraform is installed), for example:
     ```bash
     cd $GIT_ROOT/deployment/terraform/devops
-    terraform init
-    terraform apply
+    terraform init && terraform apply
     ```
-
-    Your `devops` project should now be ready.
-
-1. In `$MYSTUDIES_TEMPLATE`, set `enable_gcs_backend` to `true`, and regenerate
-    the Teraform configs.
-
+1. Backup the state of your `{PREFIX}-{ENV}-devops` project to the newly created state bucket by setting the `enable_gcs_backend` flag in [`mystudies.hcl`](/deployment/mystudies.hcl) to `true` and regenerating the Terraform configs, for example:
     ```bash
+    sed -e 's/enable_gcs_backend = false/enable_gcs_backend = true/g' \
+      -i.backup $GIT_ROOT/deployment/mystudies.hcl    
     tfengine --config_path=$ENGINE_CONFIG --output_path=$GIT_ROOT/deployment/terraform
-    ```
-
-1. Backup the state of the `devops` project to the newly created state bucket
-    by running the following command.
-
-    ```bash
+    cd $GIT_ROOT/deployment/terraform/devops
     terraform init -force-copy
     ```
-
-#### CICD pipelines
-
-1. Install the Cloud Build app and
-    [connect your GitHub repository](https://console.cloud.google.com/cloud-build/triggers/connect)
-    to {PREFIX}-{ENV}-devops project by following the steps in
-    [Installing the Cloud Build app](https://cloud.google.com/cloud-build/docs/automating-builds/create-github-app-triggers#installing_the_cloud_build_app).
-
-    To perform this operation, you need Admin permission in that GitHub
-    repository.
-
-1. Deploy the `cicd/` folder to set up CICD pipelines.
-
+1. Open [Cloud Build](https://console.cloud.google.com/cloud-build/triggers) in your new `{PREFIX}-{ENV}-devops` project and [connect](https://cloud.google.com/cloud-build/docs/automating-builds/create-github-app-triggers#installing_the_cloud_build_app) your cloned GitHub repository (skip adding triggers as Terraform will create them in the next step)
+1. Create the CICD pipeline for your deployment (this will create the Cloud Builder triggers that will run whenever a pull request containing changes to files in `$GIT_ROOT/deployment/terraform/` is raised against the GitHub branch that you specified in [`deployment.hcl`](/deployment/deployment.hcl)), for example:
     ```bash
     cd $GIT_ROOT/deployment/terraform/cicd
-    terraform init
-    terraform apply
+    terraform init && terraform apply
     ```
+### Deploy your platform infrastructure
 
-### Step 2: Deploy projects and first set of resources through CICD
-
-1. Add the following items to your `.gitignore` file to avoid accidentally
-    commit any `.terraform/` directories, `*.tfstate` or `*.tfstate.backup`
-    files generated from previous manual deployments:
-
+1. Commit your local git working directory (which now represents your desired infrastructure state) to a new branch in your cloned FDA MyStudies repository, for example using:
     ```bash
-    **/.terraform
-    *.tfstate
-    *.tfstate.*
+    cd $GIT_ROOT
+    git checkout -b initial-deployment
+    git add $GIT_ROOT/deployment/terraform
+    git commit -m "Perform initial deployment"
+    git push origin initial-deployment
     ```
+1. Trigger Cloud Build to run the Terraform pre-submit checks by using this new branch to [create](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request) a pull request against the branch you specified in [`deployment.hcl`](/deployment/deployment.hcl) (you can view the status of your pre-submit checks and re-run jobs as necessary in the [Cloud Build history](https://console.cloud.google.com/cloud-build/builds) of your `devops` project)
+1. Once your pre-submit checks have completed successfully, and you have received code review approval, merge your pull request into the main branch to trigger the `terraform apply` post-submit operation (this operation may take up to 45 minutes - you can view the status of the operation in the [Cloud Build history](https://console.cloud.google.com/cloud-build/builds) of your `devops` project)
 
-1. Commit your current local git working dir and send a Pull Request to merge
-    these configs. Make sure the presubmit tests pass and get code review
-    approvals. The CD job will then deploy the following resources for you.
+    > Note: If your pre-submit checks or post-submit `terraform apply` fail with an error related to billing accounts, you may not have the [quota](https://support.google.com/cloud/answer/6330231?hl=en) necessary to attach all of your projects to the specified billing account. You may need to [request additional quota](https://support.google.com/code/contact/billing_quota_increase).
+1. [Grant](https://cloud.google.com/iam/docs/granting-changing-revoking-access) the [`roles/owner`](https://cloud.google.com/resource-manager/docs/access-control-proj#using_basic_roles) permission to the `{PREFIX}-{ENV}-project-owners@{DOMAIN}` group for each of your newly created projects
 
-    - Audit
-        - Project
-        - All resources (log sink bucket and dataset)
-    - Secrets
-        - Project
-        - All resources (note some secrets values need to be filled manually)
-    - Networks
-        - Project
-        - All resources (VPC, subnets, bastion host, etc)
-    - Apps
-        - Project
-        - All resources (Service Accounts, GKE, DNS, Binary Authorization,
-            etc)
-    - Firebase
-        - Project
-        - Partial resources (Firestore data export buckets, PubSub, etc)
-    - Data
-        - Project
-        - Partial resources (Storage buckets, IAM bindings, etc)
+### Configure your domain for the deployment
 
-### Step 3: Setup secrets
+1. [Determine the name servers](https://cloud.google.com/dns/docs/update-name-servers#look-up-cloud-dns-name-servers) that Cloud DNS has allocated to your `{PREFIX}-{ENV}` subdomain
+    - Navigate to [DNS zones](https://console.cloud.google.com/net-services/dns/zones) in your `{PREFIX}-{ENV}-apps` project
+    - Click on the zone named `{PREFIX}-{ENV}`, then click `Registrar Setup` in the upper right to view the name servers allocated to your subdomain
+1. Update your domain’s DNS settings with your domain registrar to create a [delegated subzone](https://cloud.google.com/dns/docs/dns-overview#delegated_subzone) with the name servers allocated by Cloud DNS (this process differs across domain registrars - consult your domain registrar’s documentation to determine how to make these changes, or ask your domain’s IT administrator for help)
+    - If your domain registrar is Google Domains, you can create the delegated subzone as follows:
+         1. Log into [Google Domains](https://domains.google.com/) using the account that administers your domain
+         1. Navigate to the DNS page for your domain and scroll down to the ‘custom resource records’ section (you do not need to make changes in the other sections)
+         1. Create an NS [resource record](https://support.google.com/domains/answer/3290350) for your {PREFIX}-{ENV} subdomain that matches the name servers specified in Cloud DNS, for example:
+![Domain configuration](/documentation/images/delegated-subzone.png "Domain configuration") 
+1. [Verify](https://cloud.google.com/dns/docs/tutorials/create-domain-tutorial#step-6:-verify-your-setup) your setup (it may take up to 48 hours for DNS changes to propagate across the internet)
 
-1. Manually fill in certain secret values. This needs to be done on Google
-    Cloud Console web UI. Steps:
+### Configure your deployment’s databases
 
-    1. Navigate to {PREFIX}-{ENV}-secrets on
-        <https://console.cloud.google.com/>.
-    1. Select "Security" --> "Secret Manager" from the top-left dropdown.
-    1. Fill in the values for the secrets with prefix `manual-`.
-
-### Step 4: Setup Firestore database
-
-1. Setup Firestore database. This needs to be done on Google Cloud Console web
-    UI. Steps:
-
-    1. Navigate to {PREFIX}-{ENV}-firebase on
-        <https://console.cloud.google.com/>.
-    1. Select "Firestore" > "Data" from the top-left dropdown.
-    1. Click "SELECT NATIVE MODE" button.
-    1. Select a location from the dropdown. Ideally this should be close to
-        where the apps will be running.
-    1. Click "CREATE DATABASE" button.
-
-### Step 5: Deploy additional Firebase resources and Data resources through CICD
-
-1. In `$MYSTUDIES_TEMPLATE`, uncomment the blocks that are marked as *Step
-    5.1*, *Step 5.2*, *Step 5.3*, *Step 5.4*, *Step 5.5* and *Step 5.6*. Then
-    regenerate the Terraform configs:
-
+1. [Create](https://console.cloud.google.com/datastore/) a [*Native mode*](https://cloud.google.com/datastore/docs/firestore-or-datastore) Cloud Firestore database in your `{PREFIX}-{ENV}-firebase` project (the location selected here does not need to match the region configured in your `deployment.hcl` file) 
+1. Use Terraform and CICD to create Firestore indexes, a Cloud SQL instance, user accounts and IAM role bindings
+    - Uncomment the blocks for steps 5.1 through 5.6 in [`mystudies.hcl`](/deployment/mystudies.hcl), for example:
+         ```bash
+         sed -e 's/#5# //g' -i.backup $GIT_ROOT/deployment/mystudies.hcl
+         ```
+    - Regenerate the Terraform configs and commit the changes to your repo, for example:
+         ```bash
+         cd $GIT_ROOT
+         tfengine --config_path=$ENGINE_CONFIG --output_path=$GIT_ROOT/deployment/terraform
+         git checkout -b database-configuration
+         git add $GIT_ROOT/deployment/terraform
+         git commit -m "Configure databases"
+         git push origin database-configuration
+         ```
+    - Once your pull request pre-submit checks have completed successfully, and you have received code review approval, merge your pull request to trigger `terraform apply`(this may take up to 20 minutes - you can view the status of the operation in the [Cloud Build history](https://console.cloud.google.com/cloud-build/builds) of your `devops` project)
+1. Configure the permissions of your SQL script bucket so that your Cloud SQL instance can import the necessary initialization scripts
+    - Uncomment the blocks for Steps 6 in [`mystudies.hcl`](/deployment/mystudies.hcl), for example:
+         ```bash
+         sed -e 's/#6# //g' -i.backup $GIT_ROOT/deployment/mystudies.hcl
+         ```
+    - Regenerate the Terraform configs and commit the changes to your repo, for example:
+         ```bash
+         cd $GIT_ROOT
+         tfengine --config_path=$ENGINE_CONFIG --output_path=$GIT_ROOT/deployment/terraform
+         git checkout -b sql-bucket-permissions
+         git add $GIT_ROOT/deployment/terraform
+         git commit -m "Set SQL bucket permissions"
+         git push origin sql-bucket-permissions
+         ```
+    - Once your pull request pre-submit checks have completed successfully, and you have received code review approval, merge your pull request to trigger `terraform apply`(this may take up to 10 minutes - you can view the status of the operation in the [Cloud Build history](https://console.cloud.google.com/cloud-build/builds) of your `devops` project)
+1. Initialize your MySQL databases by importing SQL scripts
+    - Upload the necessary SQL script files to the `{PREFIX}-{ENV}-mystudies-sql-import` storage bucket that you created during Terraform deployment, for example:
+         ```bash
+         gsutil cp \
+           ${GIT_ROOT}/study-builder/sqlscript/* \
+           ${GIT_ROOT}/response-datastore/sqlscript/mystudies_response_server_db_script.sql \
+           ${GIT_ROOT}/participant-datastore/sqlscript/mystudies_app_info_update_db_script.sql \
+           ${GIT_ROOT}/participant-datastore/sqlscript/mystudies_participant_datastore_db_script.sql \
+           ${GIT_ROOT}/auth-server/sqlscript/mystudies_oauth_server_hydra_db_script.sql \
+           ${GIT_ROOT}/hydra/sqlscript/create_hydra_db_script.sql \
+           gs://${PREFIX}-${ENV}-mystudies-sql-import
+         ```
+    - Import the SQL scripts from cloud storage to your Cloud SQL instance, for example:
+         ```bash
+         gcloud sql import sql --project=${PREFIX}-${ENV}-data mystudies gs://${PREFIX}-${ENV}-mystudies-sql-import/create_hydra_db_script.sql -q
+         gcloud sql import sql --project=${PREFIX}-${ENV}-data mystudies gs://${PREFIX}-${ENV}-mystudies-sql-import/mystudies_oauth_server_hydra_db_script.sql -q
+         gcloud sql import sql --project=${PREFIX}-${ENV}-data mystudies gs://${PREFIX}-${ENV}-mystudies-sql-import/HPHC_My_Studies_DB_Create_Script.sql -q
+         gcloud sql import sql --project=${PREFIX}-${ENV}-data mystudies gs://${PREFIX}-${ENV}-mystudies-sql-import/procedures.sql -q
+         gcloud sql import sql --project=${PREFIX}-${ENV}-data mystudies gs://${PREFIX}-${ENV}-mystudies-sql-import/version_info_script.sql -q
+         gcloud sql import sql --project=${PREFIX}-${ENV}-data mystudies gs://${PREFIX}-${ENV}-mystudies-sql-import/mystudies_response_server_db_script.sql -q
+         gcloud sql import sql --project=${PREFIX}-${ENV}-data mystudies gs://${PREFIX}-${ENV}-mystudies-sql-import/mystudies_participant_datastore_db_script.sql -q
+         ```
+1. [Enable](https://console.cloud.google.com/marketplace/product/google/sqladmin.googleapis.com) the [Cloud SQL Admin API](https://cloud.google.com/sql/docs/mysql/admin-api) for your `{PREFIX}-{ENV}-apps` project, for example:
     ```bash
-    tfengine --config_path=$ENGINE_CONFIG --output_path=$GIT_ROOT/deployment/terraform
+    gcloud config set project $PREFIX-$ENV-apps && \
+      gcloud services enable sqladmin.googleapis.com
     ```
 
-1. Commit your current local git working dir and send a Pull Request to merge
-    these configs. Make sure the presubmit tests pass and get code review
-    approvals. The CD job will then deploy the resources for you.
+### Configure and deploy your applications
 
-### Step 6: Deploy SQL import bucket IAM members through CICD
+1. Make a [request](https://cloud.google.com/compute/quotas#requesting_additional_quota) to increase the [Global Compute Engine API Backend Services quota]((https://console.cloud.google.com/iam-admin/quotas/details;servicem=compute.googleapis.com;metricm=compute.googleapis.com%2Fbackend_services;limitIdm=1%2F%7Bproject%7D)) for your `{PREFIX}-{ENV}-apps` project to 20 (if it is not already set at, or beyond, this value)
+1. Enable CICD for the application directories of your cloned GitHub repository so that changes you make to the application code will automatically build the application containers for your deployment
+    - Enable [Cloud Build](https://console.cloud.google.com/cloud-build/triggers) in your `{PREFIX}-{ENV}-apps` project and [connect](https://cloud.google.com/cloud-build/docs/automating-builds/create-github-app-triggers#installing_the_cloud_build_app) your cloned GitHub repository (skip adding triggers as Terraform will create them in the next step)
+    - Uncomment  the Cloud Build triggers portion of the apps project (step 7) in [`mystudies.hcl`](/deployment/mystudies.hcl), for example:
+         ```bash
+         sed -e 's/#7# //g' -i.backup $GIT_ROOT/deployment/mystudies.hcl
+         ```
+    - Regenerate the Terraform configs and commit the changes to your repo, for example:
+         ```bash
+         cd $GIT_ROOT
+         tfengine --config_path=$ENGINE_CONFIG --output_path=$GIT_ROOT/deployment/terraform
+         git checkout -b enable-apps-CICD
+         git add $GIT_ROOT/deployment/terraform
+         git commit -m "Enable CICD for applications"
+         git push origin enable-apps-CICD
+         ```
+    - Once your pull request pre-submit checks have completed successfully, and you have received code review approval, merge your pull request to trigger `terraform apply`(this may take up to 10 minutes - you can view the status of the operation in the [Cloud Build history](https://console.cloud.google.com/cloud-build/builds) of your `devops` project)
+1. Update the Kubernetes and application configuration files with the values specific to your deployment
+    -  Replace the `<PREFIX>`, `<ENV>` and `<LOCATION>` values for each `tf-deployment.yaml` in your repo, for example:
+         ```bash
+         find $GIT_ROOT -name 'tf-deployment.yaml' \
+           -exec sed -e 's/<PREFIX>-<ENV>/'$PREFIX'-'$ENV'/g' \
+           -e 's/<LOCATION>/'$LOCATION'/g' -i.backup '{}' \;
+         ```
+    -  Replace the `<PREFIX>`, `<ENV>` and `<DOMAIN>` values in [`/deployment/kubernetes/cert.yaml`](/deployment/kubernetes/cert.yaml) and [`/deployment/kubernetes/ingress.yaml`](/deployment/kubernetes/ingress.yaml), for example:
+         ```bash
+         sed -e 's/<PREFIX>/'$PREFIX'/g' \
+           -e 's/<ENV>/'$ENV'/g' \
+           -e 's/<DOMAIN>/'$DOMAIN'/g' -i.backup \
+           $GIT_ROOT/deployment/kubernetes/cert.yaml
+         sed -e 's/<PREFIX>/'$PREFIX'/g' \
+           -e 's/<ENV>/'$ENV'/g' \
+           -e 's/<DOMAIN>/'$DOMAIN'/g' -i.backup \
+           $GIT_ROOT/deployment/kubernetes/ingress.yaml
+         ```
+    - In [`/participant-manager/src/environments/environment.prod.ts`](/participant-manager/src/environments/environment.prod.ts), replace `<BASE_URL>` with your `participants.{PREFIX}-{ENV}.{DOMAIN}` value and `<auth-server-client-id>` with the value of your `auto-auth-server-client-id` secret (you can find this value in the [Secret Manager](https://console.cloud.google.com/security/secret-manager/) of your `{PREFIX}-{ENV}-secrets` project), for example:
+         ```bash
+         gcloud config set project $PREFIX-$ENV-secrets
+         export auth_server_client_id=$( \
+           gcloud secrets versions access latest --secret="auto-auth-server-client-id")
+         sed -e 's/<BASE_URL>/participants.'$PREFIX'-'$ENV'.'$DOMAIN'/g' \
+           -e 's/<AUTH_SERVER_CLIENT_ID>/'$auth_server_client_id'/g' -i.backup \
+           $GIT_ROOT/participant-manager/src/environments/environment.prod.ts
+         ```
+    - Commit the changes to your repo, for example:
+         ```bash
+         cd $GIT_ROOT
+         git checkout -b configure-application-properties
+         git add $GIT_ROOT
+         git commit -m "Initial configuration of application properties"
+         git push origin configure-application-properties
+         ```
+    - Once your pull request pre-submit checks have completed successfully, and you have received code review approval, merge your pull request to build your container images, after which they will be available in the Container Registry of your apps project at `http://gcr.io/{PREFIX}-{ENV}-apps` (this may take up to 10 minutes - you can view the status of the operation in the [Cloud Build history](https://console.cloud.google.com/cloud-build/builds) of your `{PREFIX}-{ENV}-apps` project)
+1. Open [Secret Manager](https://console.cloud.google.com/security/secret-manager) for your `{PREFIX}-{ENV}-secrets` project and fill in the values for secrets with the prefix “manual-” (or set your `gcloud` project with `gcloud config set project $PREFIX-$ENV-secrets` and use the commands described below - afterwards clear your shell history with `history -c`)
 
-1. In `$MYSTUDIES_TEMPLATE`, uncomment the blocks that are marked as *Step 6*
-    and regenerate the Terraform configs:
+    Manually set secret | Description | When to set | Example command
+    --------------------------|-------------------|----------------------|-------------------
+    `manual-mystudies-email-address` | The login of the email account you want MyStudies to use to send system-generated emails | Set this value now or enter a placeholder | `echo -n "<SECRET_VALUE>" \| gcloud secrets versions add "manual-mystudies-email-address" --data-file=-`
+    `manual-mystudies-email-password` | The password for that email account | Set this value now or enter a placeholder | `echo -n "<SECRET_VALUE>" \| gcloud secrets versions add "manual-mystudies-email-password" --data-file=-`
+    `manual-mystudies-contact-email-address` | The email address that the in-app contact and feedback forms will send messages to | Set this value now or enter a placeholder | `echo -n "<SECRET_VALUE>" \| gcloud secrets versions add "manual-mystudies-contact-email-address" --data-file=-`
+    `manual-mystudies-from-email-address` | The return email address that is shown is system-generated messages (for example, `no-reply@example.com`) | Set this value now or enter a placeholder | `echo -n "<SECRET_VALUE>" \| gcloud secrets versions add "manual-mystudies-from-email-address" --data-file=-`
+    `manual-mystudies-from-email-domain` | The domain of the above email address (just the value after “@”) | Set this value now or enter a placeholder | `echo -n "<SECRET_VALUE>" \| gcloud secrets versions add "manual-mystudies-from-email-domain" --data-file=-`
+    `manual-mystudies-smtp-hostname` | The hostname for your email account’s SMTP server (for example, `smtp.gmail.com`) | Set this value now or enter a placeholder | `echo -n "<SECRET_VALUE>" \| gcloud secrets versions add "manual-mystudies-smtp-hostname" --data-file=-`
+    `manual-mystudies-smtp-use-ip-allowlist` | Typically ‘false’; if ‘true’, the platform will not authenticate to the email server and will rely on the allowlist configured in the SMTP service | Set this value to `true` or `false` now (you can update it later) | `echo -n "false" \| gcloud secrets versions add "manual-mystudies-smtp-use-ip-allowlist" --data-file=-`
+    `manual-log-path` | The path to a directory within each application’s container where your logs will be written (for example `/logs`) | Set this value now | `echo -n "/logs" \| gcloud secrets versions add "manual-log-path" --data-file=-`
+    `manual-org-name` | The name of your organization that is displayed to users, for example ‘Sincerely, the `manual-org-name` support team’ | Set this value now | `echo -n "<SECRET_VALUE>" \| gcloud secrets versions add "manual-org-name" --data-file=-`
+    `manual-terms-url` | URL for a terms and conditions page that the applications will link to (for example, `https://example.com/terms`) | Set this value now or enter a placeholder | `echo -n "<SECRET_VALUE>" \| gcloud secrets versions add "manual-terms-url" --data-file=-`
+    `manual-privacy-url` | URL for a privacy policy page that the applications will link to (for example, `https://example.com/privacy`) | Set this value now or enter a placeholder | `echo -n "<SECRET_VALUE>" \| gcloud secrets versions add "manual-privacy-url" --data-file=-`
+    `manual-mobile-app-appid` | The value of the `App ID` (15 characters max) that you will configure on the Settings page of the [Study builder](/study-builder/) user interface when you create your first study (you will also use this same value when configuring your mobile applications for deployment) | Set now if you know what value you will use when you create your first study - otherwise enter a placeholder and update once you have created a study in the [Study builder](/study-builder) | `echo -n "<SECRET_VALUE>" \| gcloud secrets versions add "manual-mobile-app-appid" --data-file=-`
+    `manual-android-bundle-id` | The value of [`applicationId`](https://developer.android.com/studio/build/application-id) that you will configure in [`Android/app/build.gradle`](/Android/app/build.gradle) during [Android configuration](/Android/), for example `{PREFIX}_{ENV}.{DOMAIN}` (note that some characters are not permitted) | If you know what value you will use during [Android](/Android/) deployment you can set this now, otherwise enter a placeholder and update later (leave as placeholder if you will be deploying to iOS only) | `echo -n "<SECRET_VALUE>" \| gcloud secrets versions add "manual-android-bundle-id" --data-file=-`
+    `manual-fcm-api-url` | [URL](https://firebase.google.com/docs/reference/fcm/rest) of your Firebase Cloud Messaging API ([documentation](https://firebase.google.com/docs/cloud-messaging/http-server-ref)) | Set now if you know what this value will be - otherwise create a placeholder and update after completing your [Android](/Android/) deployment (leave as placeholder if you will be deploying to iOS only) | `echo -n "<SECRET_VALUE>" \| gcloud secrets versions add "manual-fcm-api-url" --data-file=-`
+    `manual-android-server-key` | The Firebase Cloud Messaging [server key](https://firebase.google.com/docs/cloud-messaging/auth-server#authorize-legacy-protocol-send-requests) that you will obtain during [Android configuration](/Android/) | Set now if you know what this value will be - otherwise create a placeholder and update after completing your [Android](/Android/) deployment (leave as placeholder if you will be deploying to iOS only) | `echo -n "<SECRET_VALUE>" \| gcloud secrets versions add "manual-android-server-key" --data-file=-`
+    `manual-android-deeplink-url` | The URL to redirect to after Android login (for example, `app://{PREFIX}-{ENV}.{DOMAIN}/mystudies`) | Set now if you know what this value will be - otherwise create a placeholder and update after completing your [Android](/Android/) deployment (leave as placeholder if you will be deploying to iOS only) | `echo -n "<SECRET_VALUE>" \| gcloud secrets versions add "manual-android-deeplink-url" --data-file=-`
+    `manual-ios-bundle-id` | The value you will obtain from Xcode (Project target > General tab > Identity section > Bundle identifier) during [iOS configuration](/iOS/) - for a production application, the bundle ID needs to be verified with Apple and is usually a reverse domain name that you own; it is a unique app identifier and application capabilities are mapped to this value ([details](https://developer.apple.com/documentation/appstoreconnectapi/bundle_ids)) | Set now if you know what this value will be - otherwise create a placeholder and update after completing your [iOS](/iOS/) deployment (leave as placeholder if you will be deploying to Android only) | `echo -n "<SECRET_VALUE>" \| gcloud secrets versions add "manual-ios-bundle-id" --data-file=-`
+    `manual-ios-certificate` | The value of the Base64 converted `.p12` file that you will obtain during [iOS configuration](/iOS/) | Set now if you know what this value will be - otherwise create a placeholder and update after completing your [iOS](/iOS/) deployment (leave as placeholder if you will be deploying to Android only) | `echo -n "<SECRET_VALUE>" \| gcloud secrets versions add "manual-ios-certificate" --data-file=-`
+    `manual-ios-certificate-password` | The value of the password for the `.p12` certificate (necessary if your certificate is encrypted - otherwise leave empty) | Set now if you know what this value will be - otherwise create a placeholder and update after completing your [iOS](/iOS/) deployment (leave as placeholder if you will be deploying to Android only) | `echo -n "<SECRET_VALUE>" \| gcloud secrets versions add "manual-ios-certificate-password" --data-file=-`
+    `manual-ios-deeplink-url` | The URL to redirect to after iOS login (for example, `app://{PREFIX}-{ENV}.{DOMAIN}/mystudies`) | Set now if you know what this value will be - otherwise create a placeholder and update after completing your [iOS](/iOS/) deployment (leave as placeholder if you will be deploying to Android only) | `echo -n "<SECRET_VALUE>" \| gcloud secrets versions add "manual-ios-deeplink-url" --data-file=-`
+     > Note: When updating secrets after this initial deployment, you must refresh your Kubernetes cluster and restart the relevant pods to ensure the updated secrets are propagated to your applications (you do not need to do this now - only when making updates later), for example you can update your Kubernetes state with:
+     ```bash
+     cd $GIT_ROOT/deployment/terraform/kubernetes
+     terraform init && terraform apply
+     ```
+    > then, restart the pods by deleting them in the Kubernetes dashboard or running:
+     ```bash
+     APP_PATH=<path_to_component_to_restart> # for example, $GIT_ROOT/auth-server
+     kubectl scale --replicas=0 -f $APP_PATH/tf-deployment.yaml && \
+     kubectl scale --replicas=1 -f $APP_PATH/tf-deployment.yaml
+     ```
+     > If you rotate an application’s ‘client_id’ or ‘client_secret’, such as `auto-response-datastore-client-id` or `auto-response-datastore-secret-key`, you must register the new values in Hydra by re-running the `register_clients_in_hydra.sh` script or executing the appropriate REST requests directly (see [`/hydra/README.md`](/hydra/README.md) for more information about working with Hydra manually)
+1. Finish Kubernetes cluster configuration and deployment
+    - Configure the remaining resources with Terraform, for example: 
+         ```bash
+         cd $GIT_ROOT/deployment/terraform/kubernetes/
+         terraform init && terraform apply
+         ```
+    - Set your `kubectl` credentials, for example:
+         ```bash
+         gcloud container clusters get-credentials "$PREFIX-$ENV-gke-cluster" \
+           --region=$LOCATION --project="$PREFIX-$ENV-apps"
+         ```
+    - Apply the pod security policies, for example:
+         ```bash
+         kubectl apply \
+           -f $GIT_ROOT/deployment/kubernetes/pod_security_policy.yaml \
+           -f $GIT_ROOT/deployment/kubernetes/pod_security_policy-istio.yaml
+         ```
+    - Apply all deployments, for example:
+         ```bash
+         kubectl apply \
+           -f $GIT_ROOT/study-datastore/tf-deployment.yaml \
+           -f $GIT_ROOT/response-datastore/tf-deployment.yaml \
+           -f $GIT_ROOT/participant-datastore/consent-mgmt-module/tf-deployment.yaml \
+           -f $GIT_ROOT/participant-datastore/enroll-mgmt-module/tf-deployment.yaml \
+           -f $GIT_ROOT/participant-datastore/user-mgmt-module/tf-deployment.yaml \
+           -f $GIT_ROOT/study-builder/tf-deployment.yaml \
+           -f $GIT_ROOT/auth-server/tf-deployment.yaml \
+           -f $GIT_ROOT/participant-manager-datastore/tf-deployment.yaml \
+           -f $GIT_ROOT/hydra/tf-deployment.yaml \
+           -f $GIT_ROOT/participant-manager/tf-deployment.yaml
+         ```
+    - Apply all services, for example:
+         ```bash
+         kubectl apply \
+           -f $GIT_ROOT/study-datastore/tf-service.yaml \
+           -f $GIT_ROOT/response-datastore/tf-service.yaml \
+           -f $GIT_ROOT/participant-datastore/consent-mgmt-module/tf-service.yaml \
+           -f $GIT_ROOT/participant-datastore/enroll-mgmt-module/tf-service.yaml \
+           -f $GIT_ROOT/participant-datastore/user-mgmt-module/tf-service.yaml \
+           -f $GIT_ROOT/study-builder/tf-service.yaml \
+           -f $GIT_ROOT/auth-server/tf-service.yaml \
+           -f $GIT_ROOT/participant-manager-datastore/tf-service.yaml \
+           -f $GIT_ROOT/hydra/tf-service.yaml \
+           -f $GIT_ROOT/participant-manager/tf-service.yaml
+         ```
+    - Apply the certificate and the ingress, for example:
+         ```bash
+         kubectl apply \
+           -f $GIT_ROOT/deployment/kubernetes/cert.yaml \
+           -f $GIT_ROOT/deployment/kubernetes/ingress.yaml
+         ```
+    - Update firewalls:
+        - Run `kubectl describe ingress $PREFIX-$ENV`
+        - Look at the suggested commands under "Events", in the form of "Firewall
+        change required by network admin"
+        - Run each of the suggested commands
+1. Verify the status of your Kubernetes cluster
+     - Check the [Kubernetes ingress dashboard](https://console.cloud.google.com/kubernetes/ingresses) in your `{PREFIX}-{ENV}-apps` project to view the status of your cluster ingress (if status is not green, repeat the firewall step above)
+    - Check the [Kubernetes workloads dashboard](https://console.cloud.google.com/kubernetes/workload) in your `{PREFIX}-{ENV}-apps` project to view the status of your applications (confirm all applications are green before proceeding - it can take up to 15 minutes for all containers to become operational)
+    - [Check the status](https://cloud.google.com/load-balancing/docs/ssl-certificates/google-managed-certs#certificate-resource-status) of your Kubernetes cluster SSL certificates on the certificates page of your `{PREFIX}-{ENV}-apps` project’s [load balancing](https://console.cloud.google.com/net-services/loadbalancing/) ‘advanced menu’ (both the `participants.{PREFIX}-{ENV}.{DOMAIN}` and `studies.{PREFIX}-{ENV}.{DOMAIN}` certificates must be green for your deployment to use `https`) 
+1. Configure your initial application credentials
+    - Create the [`Hydra`](/hydra/) credentials for server-to-server requests by running [`register_clients_in_hydra.sh`](/deployment/scripts/register_clients_in_hydra.sh), for example:
+         ```bash
+         $GIT_ROOT/deployment/scripts/register_clients_in_hydra.sh \
+           $PREFIX $ENV $DOMAIN
+         ```
+    - Create your first admin user account for the [`Participant manager`](/participant-manager/) application by running the [`create_participant_manager_superadmin.sh`](/deployment/scripts/create_participant_manager_superadmin.sh) script to generate and import a SQL dump file for the [`Participant datastore`](/participant-datastore/) database (the password you specify must be at least 8 characters long and contain lower case, upper case, numeric and special characters), for example:
+         ```bash
+         $GIT_ROOT/deployment/scripts/create_participant_manager_superadmin.sh \
+           $PREFIX $ENV <YOUR_DESIRED_LOGIN_EMAIL> <YOUR_DESIRED_PASSWORD>
+         ```
+    - Create your first admin user account for the [`Study builder`](/study-builder/) application by running the [`create_study_builder_superadmin.sh`](/deployment/scripts/create_study_builder_superadmin.sh) script to generate and import a SQL dump file for the [`Study datastore`](/study-datastore/) database, for example:
+         ```bash
+         sudo apt-get install apache2-utils -y
+         $GIT_ROOT/deployment/scripts/create_study_builder_superadmin.sh \
+           $PREFIX $ENV <YOUR_DESIRED_LOGIN_EMAIL> <YOUR_DESIRED_PASSWORD>
+         ```
 
+### Configure your first study
+
+1. Navigate your browser to `studies.{PREFIX}-{ENV}.{DOMAIN}/studybuilder/` (the trailing slash is necessary) and use the account credentials that you created with the `create_study_builder_superadmin.sh` script to log into the [`Study builder`](/study-builder/) user interface
+1. Change your password, then create any additional administrative accounts that you might need
+1. Create a new study with the `App ID` that you set in the `manual-mobile-app-appid` secret, or choose a new `App ID` that you will update `manual-mobile-app-appid` with
+1. Publish your study to propagate your study values to the other platform components
+1. Navigate your browser to `participants.{PREFIX}-{ENV}.{DOMAIN}/participant-manager/` (the trailing slash is necessary), then use the account credentials that you created with the `create_participant_manager_superadmin.sh` script to log into the [`Participant manager`](/participant-manager/) user interface (if the `Participant Manager` application fails to load, confirm you are using `https` - this deployment requires `https` to be fully operational)
+1. You will be asked to change your password; afterwards you can create any additional administrative accounts that you might need
+1. Confirm your new study is visible in the `Participant manager` interface
+
+### Prepare your mobile applications
+
+1. Follow the instructions in either or both [`Android`](/Android/) and [`iOS`](/iOS/) deployment guides (if you haven’t created a study yet, you can configure the mobile applications with the `APP_ID` you plan on using when you create your first study in the [`Study builder`](/study-builder/))
+1. Open Secret Manager in your `{PREFIX}-{ENV}-secrets` project and update the secrets you previously configured with placeholder values (you can skip this step if you already configured your secrets with the appropriate values - if you do update secret values, make sure to refresh your Kubernetes cluster and applications as described above)
+    - `manual-mobile-app-appid` is the value of the `App ID` (15 characters max) that you configured, or will configure, on the Settings page of the [`Study builder`](/study-builder/)
+    - `manual-android-bundle-id` is the value of [`applicationId`](https://developer.android.com/studio/build/application-id) that you configured in [`Android/app/build.gradle`](/Android/app/build.gradle), for example `{PREFIX}_{ENV}.{DOMAIN}` (note that some characters are not permitted)
+    - `manual-fcm-api-url` is the URL of your [Firebase Cloud Messaging API](https://firebase.google.com/docs/reference/fcm/rest)
+    - `manual-android-server-key` is your Firebase Cloud Messaging [server key](https://firebase.google.com/docs/cloud-messaging/auth-server#authorize-legacy-protocol-send-requests)
+    - `manual-android-deeplink-url` is the URL to redirect to after Android login (for example, `app://{PREFIX}-{ENV}.{DOMAIN}/mystudies`)
+    - `manual-ios-bundle-id` is the value you obtained from Xcode (in production use-cases, this  bundle ID needs to be [verified with Apple](https://developer.apple.com/documentation/appstoreconnectapi/bundle_ids))
+    - `manual-ios-certificate` is the value of the Base64 converted `.p12` file
+    - `manual-ios-certificate-password` is the value of the password for the `.p12` certificate 
+    - `manual-ios-deeplink-url` is the URL to redirect to after iOS login
+1. Initialize your `Participant datastore` database to work with your mobile applications
+    - Once a study with the `App ID` corresponding to the `manual-mobile-app-appid` secret is created and published using the [`Study builder`](/study-builder) user interface, a corresponding 
+app record will appear in the [`Participant manager`](/participant-manager/) user interface (if you created a study before all of your platform components were operational, you can reinitialize this process by using the `Study builder` user interface to pause and resume the study) 
+    - Once the `App ID` appears in `Participant manager`, run the [`deployment/scripts/copy_app_info_to_sql.sh`](/deployment/scripts/copy_app_info_to_sql.sh) script to update the remaining databases, for example:
+         ```bash
+         $GIT_ROOT/deployment/scripts/copy_app_info_to_sql.sh $PREFIX $ENV
+         ```
+
+### Clean up
+
+1. Remove your user account from the groups you no longer need access to
+1. Revoke user access in your environment, for example:
     ```bash
-    tfengine --config_path=$ENGINE_CONFIG --output_path=$GIT_ROOT/deployment/terraform
+    gcloud auth revoke <user>@<domain> -q && \
+      gcloud auth application-default revoke -q
     ```
-
-1. Commit your current local git working dir and send a Pull Request to merge
-    these configs. Make sure the presubmit tests pass and get code review
-    approvals. The CD job will then deploy the resources for you.
-
-### Step 7: Deploy Cloud Build Triggers for server containers
-
-1. Install the Cloud Build app and connect your GitHub repository to
-    {PREFIX}-{ENV}-apps project by following the steps in
-    [Installing the Cloud Build app](https://cloud.google.com/cloud-build/docs/automating-builds/create-github-app-triggers#installing_the_cloud_build_app).
-
-    To perform this operation, you need Admin permission in that GitHub
-    repository.
-
-1. In `$MYSTUDIES_TEMPLATE`, uncomment the Cloud Build Triggers part in the
-    Apps project, and regenerate the Terraform configs.
-
-1. Commit your current local git working dir and send a Pull Request to merge
-    these configs. Make sure the presubmit tests pass and get code review
-    approvals. The CD job will then deploy the resources for you.
-
-### Step 8: Kubernetes deployment
-
-1. Follow [Kubernetes README.md](./kubernetes/README.md) to deploy the
-    Kubernetes resources in the GKE cluster.
-
-### Step 9: Secrets setup
-
-1. Run
-    [register_clients_in_hydra.sh $PREFIX $ENV](./scripts/register_clients_in_hydra.sh),
-    passing your deployment PREFIX, ENV and LOCATION as parameters. This script will
-    register each application in hydra using the generated client id and secret
-    keys.
-
-### Step 10: Superadmin accounts
-
-In order to access Study Builder or Participant Manager web UIs for the first
-time, an initial superadmin account needs to be generated for each application.
-
-1. **Participant Manager**
-
-`create_participant_manager_superadmin.sh` accepts an email and password and
-generates an initial superadmin account for Participant Manager.
-
-```bash
-./scripts/create_participant_manager_superadmin.sh <prefix> <env> <email> <password>
-```
-
-1. **Study Builder**
-
-`create_study_builder_superadmin.sh` accepts an email and password and generates
-an initial superadmin account for Study Builder.
-
-```bash
-./scripts/create_study_builder_superadmin.sh <prefix> <env> <email> <password>
-```
-
-### Step 11: Mobile app setups
-
-1. Build and distribute iOS and Android apps following their individual
-    instructions. See [iOS](../iOS/README.md) and [Android](../Android/README.md)
-    configuration instructions.
-
-
-### Step 12: Mobile app setup in participant manager
-
-An app record is a representation of your mobile apps associated with an
-FDA MyStudies deployment. App is identified by APP_ID, which is the value you
-set in secret manager for `manual-mobile-app-appid`.
-
-After a study is created (in study builder) that uses this App ID, a corresponding
-app record will be created in the Participant Manager.
-
-**Note** Current deployment only supports a single App
-(using `manual-mobile-app-appid`); and it requires the following
-manual step to pass mobile info from Secret Manager to CloudSQL.
-
-1. Once the app is available in Participant Manager, Run
-    [copy_app_info_to_sql.sh](scripts/copy_app_info_to_sql.sh)
-    passing your deployment PREFIX and ENV.
-
-    The secrets accessed by this script are:
+1. Optionally, confirm no other users are logged in, for example:
     ```bash
-    # bundleID used for the Android App.
-    manual-android-bundle-id
-    # found under settings > cloud messaging in the android app defined in your firebase project.
-    manual-android-server-key
-    # bundleID used to build and distribute the iOS App.
-    manual-ios-bundle-id
-    # push notifications certificate in encrypted .p12 format.
-    manual-ios-certificate
-    # push notifications certificate password.
-    manual-ios-certificate-password
-    # redirect links to mobile apps, e.g. app://mydeploymentdomain.com/mystudies
-    manual-ios-deeplink-url
-    manual-android-deeplink-url
-    ```
+    gcloud auth list
+    ``` 
 
-### Step 13: Clean up
-
-1. Revoke your super admin access by running `gcloud auth revoke` and
-    authenticate as a normal user for daily activities.
+***
+<p align="center">Copyright 2020 Google LLC</p>

--- a/deployment/deployment.hcl
+++ b/deployment/deployment.hcl
@@ -12,16 +12,36 @@ template "mystudies" {
   # The following values are placeholder values, change and adjust them according to
   # your use case and organization needs.
   data = {
-    prefix           = "example"
-    env              = "dev"
-    folder_id        = "0000000000"
-    billing_account  = "XXXXXX-XXXXXX-XXXXXX"
-    domain           = "example.com"
-    default_location = "us-central1"
-    default_zone     = "a"
-    github_owner     = "GoogleCloudPlatform"
-    github_repo      = "example"
-    github_branch    = "master"
+    # Prefix that will be prepended to your project and resource names
+    # For example, "mystudies"
+    prefix           = "<PREFIX>"
+    # Environment label that will be appended to PREFIX in your project and resource names
+    # For example, "dev"
+    env              = "<ENV>"
+    # Id of the folder you are deploying into
+    # In the form of "0000000000000"
+    folder_id        = "<FOLDER_ID>"
+    # Billing account that your projects will be attached to
+    # In the form of "XXXXXX-XXXXXX-XXXXXX"
+    billing_account  = "<BILLING_ACCOUNT>"
+    # Domain that your applications URLs will belong to
+    # For example, "example.com"
+    domain           = "<DOMAIN>"
+    # Default cloud region that your resources will be created in
+    # For example, "us-central1"
+    default_location = "<LOCATION>"
+    # Default zone within that region that your resources will be created in
+    # For example, "a"
+    default_zone     = "<ZONE>"
+    # The account or organization that your cloned github repo belongs to 
+    # For example, "GoogleCloudPlatform"
+    github_owner     = "<REPO_OWNER>"
+    # The name of your cloned github repo 
+    # For example, "fda-mystudies"
+    github_repo      = "<REPO>"
+    # The branch of your cloned repo that your CICD pipelines will monitor
+    # For example, "develop"
+    github_branch    = "<REPO_BRANCH>"
     # GKE master authorized networks.
     # Comment out this block if you would like to allow connections from anywhere.
     master_authorized_networks = [

--- a/deployment/kubernetes/README.md
+++ b/deployment/kubernetes/README.md
@@ -1,26 +1,26 @@
-# Kubernetes Setup
+<!--
+ Copyright 2020 Google LLC
+ Use of this source code is governed by an MIT-style
+ license that can be found in the LICENSE file or at
+ https://opensource.org/licenses/MIT.
+-->
 
-This directory contains some Kubernetes resources common to all the apps.
-
-## Kubernetes Files Locations
-
-All files below are relative to the root of the repo.
-
+This directory contains some Kubernetes resources common to all applications. All files below are relative to the root of the repo:
 * kubernetes/
   * cert.yaml
     * A Kubernetes ManagedCertificate for using
             [Google-managed SSL certificates](https://cloud.google.com/kubernetes-engine/docs/how-to/managed-certs).
   * ingress.yaml
     * A Kubernetes Ingress for routing HTTP calls to services in the
-            cluster.
+            cluster
   * pod_security_policy.yaml
-    * A restrictive Pod Security Policy that applies to the cluster apps.
+    * A restrictive Pod Security Policy that applies to the cluster apps
   * pod_security_policy-istio.yaml
     * A looser Pod Security Policy that only applies to Istio containers
-            in the cluster.
+            in the cluster
   * kubeapply.sh
     * A helper script that applies all resources to the cluster. Not
-            required, the manual steps will be described below.
+            required, the manual steps will be described below
 * auth-server/
   * tf-deployment.yaml
     * A Kubernetes Deployment, deploying the app along with its secrets.
@@ -28,9 +28,9 @@ All files below are relative to the root of the repo.
         setup.
   * tf-service.yaml
     * A Kubernetes Service, exposing the app to communicate with other apps
-        and the Ingress.
+        and the Ingress
     * This is forked from service.yaml with modifications for the Terraform
-        setup.
+        setup
 * response-datastore/
   * same as auth-server
 * study-builder/
@@ -46,252 +46,5 @@ All files below are relative to the root of the repo.
 * participant-manager/
   * same as auth-server
 
-## Setup
-
-### Prerequisites
-
-Install the following dependencies and add them to your PATH:
-
-* [gcloud](https://cloud.google.com/sdk/gcloud)
-* [gsutil](https://cloud.google.com/storage/docs/gsutil_install)
-* [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl)
-
-Find the following values as defined in your copy of `deployment.hcl`:
-
-* `<prefix>`
-* `<env>`
-
-Also note the following project IDs which will be used in subsequent
-instructions:
-
-* Apps project ID: `<prefix>-<env>-apps`
-* Data project ID: `<prefix>-<env>-data`
-* Firebase project ID: `<prefix>-<env>-firebase`
-
-### Terraform
-
-Follow the [deployment.md](../deployment.md) to create the infrastructure. This
-will create a GKE cluster and a Cloud SQL MySQL database instance.
-
-### SQL
-
-There are some SQL dump files in this repo that need to be imported before
-deploying the apps.
-
-The gcloud import command only imports from GCS buckets. The Terraform setup
-creates a bucket and gives the SQL instance permission to read files from it.
-The bucket is named `<prefix>-<env>-mystudies-sql-import`; for example,
-`example-dev-mystudies-sql-import`.
-
-Upload the SQL files to the bucket:
-
-```bash
-gsutil cp \
-  ./study-builder/sqlscript/* \
-  ./response-datastore/sqlscript/mystudies_response_server_db_script.sql \
-  ./participant-datastore/sqlscript/mystudies_participant_datastore_db_script.sql \
-  ./hydra/sqlscript/create_hydra_db_script.sql \
-  gs://<prefix>-<env>-mystudies-sql-import
-```
-
-Find the name of your Cloud SQL DB instance. If looking at the GCP Console, this
-is just the instance name, is **not** the "Instance connection name". Example:
-if the connection name is "myproject-data:us-east1:mystudies", you should use
-just "mystudies".
-
-Import the scripts, in this order:
-
-#### Hydra
-
-```bash
-gcloud sql import sql --project=<prefix>-<env>-data <instance-name> gs://<prefix>-<env>-mystudies-sql-import/create_hydra_db_script.sql
-```
-
-#### Study builder
-
-```bash
-gcloud sql import sql --project=<prefix>-<env>-data <instance-name> gs://<prefix>-<env>-mystudies-sql-import/HPHC_My_Studies_DB_Create_Script.sql
-gcloud sql import sql --project=<prefix>-<env>-data <instance-name> gs://<prefix>-<env>-mystudies-sql-import/procedures.sql
-gcloud sql import sql --project=<prefix>-<env>-data <instance-name> gs://<prefix>-<env>-mystudies-sql-import/version_info_script.sql
-```
-
-#### Response datastore
-
-```bash
-gcloud sql import sql --project=<prefix>-<env>-data <instance-name> gs://<prefix>-<env>-mystudies-sql-import/mystudies_response_server_db_script.sql
-```
-
-#### Participant datastore
-
-```bash
-gcloud sql import sql --project=<prefix>-<env>-data <instance-name> gs://<prefix>-<env>-mystudies-sql-import/mystudies_participant_datastore_db_script.sql
-```
-
-### Kubernetes Config Values
-
-You may need to make some changes to the Kubernetes configs to match your
-organization and deployment.
-
-In each tf-deployment.yaml file listed below (paths are relative to the
-root of the repo):
-
-1. auth-server/tf-deployment.yaml
-1. hydra/tf-deployment.yaml
-1. response-datastore/tf-deployment.yaml
-1. study-builder/tf-deployment.yaml
-1. study-datastore/tf-deployment.yaml
-1. participant-datastore/consent-mgmt-module/tf-deployment.yaml
-1. participant-datastore/enroll-mgmt-module/tf-deployment.yaml
-1. participant-datastore/user-mgmt-module/tf-deployment.yaml
-1. participant-manager-datastore/tf-deployment.yaml
-1. participant-manager/tf-deployment.yaml
-
-Do the following:
-
-* For all images except `gcr.io/cloudsql-docker/gce-proxy`, replace the
-    `gcr.io/<project>` part with `gcr.io/<prefix>-<env>-apps`
-* For the cloudsql-proxy container, set the `-instances` flag with
-    `-instances=<cloudsq-instance-connection-name>=tcp:3306`
-
-In the ./kubernetes/cert.yaml file:
-
-* Change the name and domain to match your organization.
-
-In the ./kubernetes/ingress.yaml file:
-
-* Change the `networking.gke.io/managed-certificates` annotation to match the
-    name in ./kubernetes/cert.yaml.
-* Change the name and the `kubernetes.io/ingress.global-static-ip-name`
-    annotation to match your organization.
-* Change the hosts to match your deployed env and what you have updated in 
-    ./kubernetes/cert.yaml.
-
-In ./participant-manager/src/environments/environment.prod.ts
-
-* Change the domain name to match your organization.
-* Change `clientId` to the value of `auto-auth-server-client-id`; this value
- can be found in your secret project's secret manager.
-
-### GKE Cluster - Terraform
-
-Some Kubernetes resources are managed through Terraform, due to ease of
-configuration. These need to be applied after the cluster already exists, and
-due to the configuration of
-[Master Authorized Networks](https://cloud.google.com/kubernetes-engine/docs/how-to/authorized-networks),
-they can't be applied by the CI/CD automation.
-
-First, authenticate via gcloud:
-
-```bash
-gcloud auth login
-gcloud auth application-default login
-```
-
-Enter the Kubernetes Terraform directory
-
-```bash
-cd deployment/terraform/kubernetes/
-```
-
-**Edit the file `terraform.tfvars`. Make sure the projects and cluster
-information is correct.**
-
-Init, plan, and apply the Terraform configs:
-
-```bash
-terraform init
-terraform plan
-terraform apply
-```
-
-(Optional) Lastly, revoke gcloud authentication
-
-```bash
-gcloud auth revoke
-gcloud auth application-default revoke
-```
-
-### GKE Cluster - kubectl
-
-Run all commands below from the repo root.
-
-First, get kubectl credentials so you can interact with the cluster:
-
-```bash
-gcloud container clusters get-credentials "<cluster-name>" --region="<region>" --project="<prefix>-<env>-apps"
-```
-
-Apply the pod security policies:
-
-```bash
-$ kubectl apply \
-  -f ./kubernetes/pod_security_policy.yaml \
-  -f ./kubernetes/pod_security_policy-istio.yaml
-```
-
-Apply all deployments:
-
-```bash
-$ kubectl apply \
-  -f ./study-datastore/tf-deployment.yaml \
-  -f ./response-datastore/tf-deployment.yaml \
-  -f ./participant-datastore/consent-mgmt-module/tf-deployment.yaml \
-  -f ./participant-datastore/enroll-mgmt-module/tf-deployment.yaml \
-  -f ./participant-datastore/user-mgmt-module/tf-deployment.yaml \
-  -f ./study-builder/tf-deployment.yaml \
-  -f ./auth-server/tf-deployment.yaml \
-  -f ./participant-manager-datastore/tf-deployment.yaml \
-  -f ./hydra/tf-deployment.yaml \
-  -f ./participant-manager/tf-deployment.yaml
-```
-
-Apply all services:
-
-```bash
-$ kubectl apply \
-  -f ./study-datastore/tf-service.yaml \
-  -f ./response-datastore/tf-service.yaml \
-  -f ./participant-datastore/consent-mgmt-module/tf-service.yaml \
-  -f ./participant-datastore/enroll-mgmt-module/tf-service.yaml \
-  -f ./participant-datastore/user-mgmt-module/tf-service.yaml \
-  -f ./study-builder/tf-service.yaml \
-  -f ./auth-server/tf-service.yaml \
-  -f ./participant-manager-datastore/tf-service.yaml \
-  -f ./hydra/tf-service.yaml \
-  -f ./participant-manager/tf-service.yaml
-```
-
-Apply the certificate and the ingress:
-
-```bash
-$ kubectl apply \
-  -f ./kubernetes/cert.yaml \
-  -f ./kubernetes/ingress.yaml
-```
-
-## Troubleshooting
-
-If the cluster has issues, there are a few things you can check:
-
-* Wait. It can take some time for all deployments to come up.
-* Run `kubectl describe pods` and `kubectl logs <pod> <container>`. 
-  Application logs are set to `warning` level by default, if you need more information, 
-  consider changing the log level to `info`.
-* Make sure all the secrets in Secret Manager have values and are not empty. 
-  After updating the value of a secret, make sure you refresh Kubernetes secrets
-  by running `terraform init` and `terraform apply` in `./terraform/kubernets`.
-* Make sure Pod Security Polices were applied. The cluster has enforcement
-    enabled, and will not start any containers if there are no Pod Security
-    Policies.
-* Make sure your cluster ingress is healthy.
-* Follow a troubleshooting guide. Examples are
-    [this](https://learnk8s.io/troubleshooting-deployments) and
-    [this](https://kubernetes.io/docs/tasks/debug-application-cluster/debug-cluster/).
-* As of now there is a known issue with Firewalls in ingress-gce. References
-    [kubernetes/ingress-gce#485](https://github.com/kubernetes/ingress-gce/issues/485)
-    and/or
-    [kubernetes/ingress-gce#584](https://github.com/kubernetes/ingress-gce/issues/584)
-    1. Run `kubectl describe ingress <ingress-name>`
-    1. Look at the suggested commands under "Events", in the form of "Firewall
-        change required by network admin: `<gcloud command>`".
-    1. Run each of the suggested commands.
+***
+<p align="center">Copyright 2020 Google LLC</p>

--- a/deployment/kubernetes/cert.yaml
+++ b/deployment/kubernetes/cert.yaml
@@ -6,15 +6,15 @@
 apiVersion: networking.gke.io/v1beta1
 kind: ManagedCertificate
 metadata:
-  name: fda-mystudies-cert-participants
+  name: <PREFIX>-<ENV>-cert-participants
 spec:
   domains:
-    - participants.fda-mystudies.domain.com
+    - participants.<PREFIX>-<ENV>.<DOMAIN>
 ---
 apiVersion: networking.gke.io/v1beta1
 kind: ManagedCertificate
 metadata:
-  name: fda-mystudies-cert-studies
+  name: <PREFIX>-<ENV>-cert-studies
 spec:
   domains:
-    - studies.fda-mystudies.domain.com
+    - studies.<PREFIX>-<ENV>.<DOMAIN>

--- a/deployment/kubernetes/ingress.yaml
+++ b/deployment/kubernetes/ingress.yaml
@@ -6,13 +6,13 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: fda-mystudies-dev
+  name: <PREFIX>-<ENV>
   annotations:
-    kubernetes.io/ingress.global-static-ip-name: mystudies-ingress-ip
-    networking.gke.io/managed-certificates: fda-mystudies-cert-participants,fda-mystudies-cert-studies
+    kubernetes.io/ingress.global-static-ip-name: <PREFIX>-<ENV>-ingress-ip
+    networking.gke.io/managed-certificates: <PREFIX>-<ENV>-cert-participants,<PREFIX>-<ENV>-cert-studies
 spec:
   rules:
-    - host: participants.fda-mystudies.domain.com
+    - host: participants.<PREFIX>-<ENV>.<DOMAIN>
       http:
         paths:
           - path: /auth-server/*
@@ -47,7 +47,7 @@ spec:
             backend:
               serviceName: participant-manager-datastore-np
               servicePort: 50000
-    - host: studies.fda-mystudies.domain.com
+    - host: studies.<PREFIX>-<ENV>.<DOMAIN>
       http:
         paths:
           - path: /study-datastore/*

--- a/deployment/scripts/create_participant_manager_superadmin.sh
+++ b/deployment/scripts/create_participant_manager_superadmin.sh
@@ -28,6 +28,7 @@ SQL_IMPORT_BUCKET=${PREFIX}-${ENV}-mystudies-sql-import
 
 TMPFILE=$(mktemp)
 
+# Update first database
 echo "USE \`oauth_server_hydra\`;" >> ${TMPFILE}
 
 SALT=`printf "%s" uuidgen | iconv -t utf-8 | openssl dgst -sha512 | sed 's/^.* //'`
@@ -59,6 +60,12 @@ GCS_FILE=gs://${SQL_IMPORT_BUCKET}/participant_manager_superadmin.sql
 echo "Copying the sql file to ${GCS_FILE}"
 gsutil mv ${TMPFILE} ${GCS_FILE}
 
+# Import the GCS file to CloudSQL.
+echo "Importing ${GCS_FILE} to CloudSQL."
+gcloud sql import sql --project=${DATA_PROJECT} mystudies ${GCS_FILE}
+gsutil rm ${GCS_FILE}
+
+# Update second database
 echo "USE \`mystudies_participant_datastore\`;" >> ${TMPFILE}
 
 echo "Insert default location"

--- a/deployment/scripts/create_participant_manager_superadmin.sh
+++ b/deployment/scripts/create_participant_manager_superadmin.sh
@@ -28,7 +28,6 @@ SQL_IMPORT_BUCKET=${PREFIX}-${ENV}-mystudies-sql-import
 
 TMPFILE=$(mktemp)
 
-# Update first database
 echo "USE \`oauth_server_hydra\`;" >> ${TMPFILE}
 
 SALT=`printf "%s" uuidgen | iconv -t utf-8 | openssl dgst -sha512 | sed 's/^.* //'`
@@ -60,12 +59,6 @@ GCS_FILE=gs://${SQL_IMPORT_BUCKET}/participant_manager_superadmin.sql
 echo "Copying the sql file to ${GCS_FILE}"
 gsutil mv ${TMPFILE} ${GCS_FILE}
 
-# Import the GCS file to CloudSQL.
-echo "Importing ${GCS_FILE} to CloudSQL."
-gcloud sql import sql --project=${DATA_PROJECT} mystudies ${GCS_FILE}
-gsutil rm ${GCS_FILE}
-
-# Update second database
 echo "USE \`mystudies_participant_datastore\`;" >> ${TMPFILE}
 
 echo "Insert default location"

--- a/deployment/scripts/create_study_builder_superadmin.sh
+++ b/deployment/scripts/create_study_builder_superadmin.sh
@@ -51,14 +51,12 @@ echo "DELETE FROM user_permission_mapping WHERE user_id=1;" >> ${TMPFILE}
 echo "REPLACE into users
 (
   user_id, first_name, last_name, email, password, role_id, created_by,
-  created_date, modified_by, modified_date, status, access_code,
-  accountNonExpired, accountNonLocked, credentialsNonExpired, password_expiry_datetime,
+  created_date, modified_by, modified_date, status, accountNonExpired, accountNonLocked, credentialsNonExpired, password_expiry_datetime,
   security_token, token_expiry_date, token_used, force_logout, access_level)
 VALUES
 (
   1, 'Account', 'Manager', '${EMAIL}', '${HASH}', 1, 1,
-  '${DATETIME}', 1, '${DATETIME}', 1, '${ACCESS_CODE}',
-  1, 1, 1, '${EXPIRY_DATETIME}',
+  '${DATETIME}', 1, '${DATETIME}', 1, 1, 1, 1, '${EXPIRY_DATETIME}',
   '${TOKEN}', '${EXPIRY_DATETIME}', 0, 'N', 'SUPERADMIN');
 " >> ${TMPFILE}
 
@@ -73,7 +71,7 @@ echo "INSERT INTO user_permission_mapping (user_id, permission_id) VALUES
 " >> ${TMPFILE}
 
 # Upload TMPFILE to GCS.
-GCS_FILE=gs://${SQL_IMPORT_BUCKET}/study_builder_supreadmin.sql
+GCS_FILE=gs://${SQL_IMPORT_BUCKET}/study_builder_superadmin.sql
 echo "Copying the sql file to ${GCS_FILE}"
 gsutil mv ${TMPFILE} ${GCS_FILE}
 

--- a/deployment/scripts/register_clients_in_hydra.sh
+++ b/deployment/scripts/register_clients_in_hydra.sh
@@ -7,25 +7,25 @@
 # Script to copy client ids and secret keys from gcloud secret and register them
 # in Hydra.
 # Run like:
-# $ ./scripts/register_clients_in_hydra.sh <prefix> <env> <base_url>
-# base_url should your env domain name, e.g. https://mystudies.mydomainname.com
+# $ ./scripts/register_clients_in_hydra.sh <prefix> <env> <domain>
+# domain should your env domain name, e.g. mydomainname.com
 
 #!/bin/bash
 if [ "$#" -ne 3 ]; then
-  echo 'Please provide deployment prefix and env in the order of <prefix> <env> <base_url of auth server>'
+  echo 'Please provide deployment prefix and env in the order of <prefix> <env> <domain>'
   exit 1
 fi
 
 PREFIX=${1}
 ENV=${2}
-AUTH_SERVER_BASE_URL=${3}
+DOMAIN=${3}
 shift 3
 
 set -e
 
 SECRET_PROJECT=${PREFIX}-${ENV}-secrets
 # used by client side applications
-SCIM_AUTH_EXTERNAL_URL="${AUTH_SERVER_BASE_URL}/auth-server"
+SCIM_AUTH_EXTERNAL_URL="participants.${PREFIX}-${ENV}.${DOMAIN}/auth-server"
 # used in server to server calls
 SCIM_AUTH_URL="http://auth-server-np:50000/auth-server"
 HYDRA_ADMIN_URL="http://hydra-admin-np:50000"
@@ -48,7 +48,11 @@ OUTPUT="curl --location --request POST \"${HYDRA_ADMIN_URL}/clients\" \\
     \"created_at\": \"${DATETIME}\",
     \"grant_types\": [\"authorization_code\",\"refresh_token\",\"client_credentials\"],
     \"token_endpoint_auth_method\": \"client_secret_basic\",
-    \"redirect_uris\": [\"${SCIM_AUTH_EXTERNAL_URL}/callback\", \"${SCIM_AUTH_URL}/callback\"]
+    \"redirect_uris\": [
+      \"http://${SCIM_AUTH_EXTERNAL_URL}/callback\",
+      \"https://${SCIM_AUTH_EXTERNAL_URL}/callback\",
+      \"${SCIM_AUTH_URL}/callback\"
+    ]
   }';
 "
 
@@ -72,7 +76,11 @@ do
     \"created_at\": \"${DATETIME}\",
     \"grant_types\": [\"client_credentials\"],
     \"token_endpoint_auth_method\": \"client_secret_basic\",
-    \"redirect_uris\": [\"${SCIM_AUTH_EXTERNAL_URL}/callback\", \"${SCIM_AUTH_URL}/callback\"]
+    \"redirect_uris\": [
+      \"http://${SCIM_AUTH_EXTERNAL_URL}/callback\",
+      \"https://${SCIM_AUTH_EXTERNAL_URL}/callback\",
+      \"${SCIM_AUTH_URL}/callback\"
+    ]
   }';"
 done
 
@@ -80,5 +88,3 @@ HYDRA_POD=`kubectl get pods --no-headers -o custom-columns=":metadata.name" | gr
 
 echo "Running registration commands in Hydra pod"
 kubectl exec ${HYDRA_POD} -c hydra-ic -- bash -c "${OUTPUT}"
-
-rm ${TMPFILE}

--- a/deployment/scripts/set_env_var.sh
+++ b/deployment/scripts/set_env_var.sh
@@ -1,0 +1,32 @@
+# !/bin/bash
+
+# Copyright 2020 Google LLC
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+# This script sets environment variables that are used throughout the deployment
+
+# PREFIX is a name you choose for your deployment that will be prepended to various
+# directories, cloud resources and URLs (for example this could be `mystudies`)
+export PREFIX=
+
+# ENV is a label you choose that will be appended to PREFIX in your directories
+# and cloud resources (for example this could be `dev`, `test` or `prod`)
+export ENV=
+
+# GIT_ROOT is the local path to the root of your cloned FDA MyStudies repository
+export GIT_ROOT=
+
+# LOCATION is the loctaion you specified for your deployment in
+# deployment.hcl, for example `us-central1`
+export LOCATION=
+
+# DOMAIN is the domain you will be using for your URLs (for example, 
+# `your_company_name.com` or `your_medical_center.edu`)
+export DOMAIN=
+
+# ENGINE_CONFIG and MYSTUDIES_TEMPLATE do not need to be changed unless
+# you have moved these files within your GitHub repo
+export ENGINE_CONFIG=${GIT_ROOT}/deployment/deployment.hcl
+export MYSTUDIES_TEMPLATE=${GIT_ROOT}/deployment/mystudies.hcl

--- a/hydra/tf-deployment.yaml
+++ b/hydra/tf-deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: hydra-ic
-        image: gcr.io/fda-mystudies-dev-apps/hydra:latest
+        image: gcr.io/<PREFIX>-<ENV>-apps/hydra:latest
         env:
         # DB ACCESS
         - name: DB_INSTANCE_URL
@@ -77,7 +77,7 @@ spec:
       - name: cloudsql-proxy
         image: gcr.io/cloudsql-docker/gce-proxy:latest
         command: ["/cloud_sql_proxy",
-                  "-instances=fda-mystudies-dev-data:us-east1:mystudies=tcp:3306",
+                  "-instances=<PREFIX>-<ENV>-data:<LOCATION>:mystudies=tcp:3306",
                   "-credential_file=/secrets/gcloud_key/key.json"]
         volumeMounts:
         - name: gcloud-key-volume

--- a/participant-datastore/consent-mgmt-module/tf-deployment.yaml
+++ b/participant-datastore/consent-mgmt-module/tf-deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: participant-consent-datastore
-          image: gcr.io/fda-mystudies-dev-apps/participant-consent-datastore:latest
+          image: gcr.io/<PREFIX>-<ENV>-apps/participant-consent-datastore:latest
           env:
             # DB ACCESS
             - name: DB_INSTANCE_URL
@@ -91,7 +91,7 @@ spec:
         - name: cloudsql-proxy
           image: gcr.io/cloudsql-docker/gce-proxy:latest
           command: ["/cloud_sql_proxy",
-            "-instances=fda-mystudies-dev-data:us-east1:mystudies=tcp:3306",
+            "-instances=<PREFIX>-<ENV>-data:<LOCATION>:mystudies=tcp:3306",
             "-credential_file=/secrets/gcloud_key/key.json"]
           volumeMounts:
           - name: gcloud-key-volume

--- a/participant-datastore/enroll-mgmt-module/tf-deployment.yaml
+++ b/participant-datastore/enroll-mgmt-module/tf-deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: participant-enroll-datastore
-          image: gcr.io/fda-mystudies-dev-apps/participant-enroll-datastore:latest
+          image: gcr.io/<PREFIX>-<ENV>-apps/participant-enroll-datastore:latest
           env:
             # DB ACCESS
             - name: DB_INSTANCE_URL
@@ -88,7 +88,7 @@ spec:
         - name: cloudsql-proxy
           image: gcr.io/cloudsql-docker/gce-proxy:latest
           command: ["/cloud_sql_proxy",
-            "-instances=fda-mystudies-dev-data:us-east1:mystudies=tcp:3306",
+            "-instances=<PREFIX>-<ENV>-data:<LOCATION>:mystudies=tcp:3306",
             "-credential_file=/secrets/gcloud_key/key.json"]
           volumeMounts:
           - name: gcloud-key-volume

--- a/participant-datastore/user-mgmt-module/tf-deployment.yaml
+++ b/participant-datastore/user-mgmt-module/tf-deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: participant-user-datastore
-          image: gcr.io/fda-mystudies-dev-apps/participant-user-datastore:latest
+          image: gcr.io/<PREFIX>-<ENV>-apps/participant-user-datastore:latest
           env:
             # DB ACCESS
             - name: DB_INSTANCE_URL
@@ -152,7 +152,7 @@ spec:
         - name: cloudsql-proxy
           image: gcr.io/cloudsql-docker/gce-proxy:latest
           command: ["/cloud_sql_proxy",
-            "-instances=fda-mystudies-dev-data:us-east1:mystudies=tcp:3306",
+            "-instances=<PREFIX>-<ENV>-data:<LOCATION>:mystudies=tcp:3306",
             "-credential_file=/secrets/gcloud_key/key.json"]
           volumeMounts:
           - name: gcloud-key-volume

--- a/participant-manager-datastore/tf-deployment.yaml
+++ b/participant-manager-datastore/tf-deployment.yaml
@@ -24,7 +24,7 @@ spec:
       containers:
         # application container
         - name: participant-manager-datastore
-          image: gcr.io/fda-mystudies-dev-apps/participant-manager-datastore:latest
+          image: gcr.io/<PREFIX>-<ENV>-apps/participant-manager-datastore:latest
           env:
             # DB ACCESS
             - name: DB_INSTANCE_URL
@@ -132,7 +132,7 @@ spec:
         - name: cloudsql-proxy
           image: gcr.io/cloudsql-docker/gce-proxy:latest
           command: ["/cloud_sql_proxy",
-            "-instances=fda-mystudies-dev-data:us-east1:mystudies=tcp:3306",
+            "-instances=<PREFIX>-<ENV>-data:<LOCATION>:mystudies=tcp:3306",
             "-credential_file=/secrets/gcloud_key/key.json"]
           volumeMounts:
           - name: gcloud-key-volume

--- a/participant-manager/Dockerfile
+++ b/participant-manager/Dockerfile
@@ -6,15 +6,16 @@
 # Stage 1
 # Installing all the dependencies and creating Dist file or building angular application
 FROM node:12.16.1 AS compile-image
-ARG basehref=/participant-manager/
+ARG BASE_HREF=/participant-manager
 WORKDIR /app
 COPY . ./
 RUN npm set progress=false
 RUN npm install
 RUN npm install -g @angular/cli
-RUN ng build --aot --prod --base-href=$basehref
+RUN ng build --aot --prod --base-href=${BASE_HREF}/
 
 # Stage2
 # copying and running the application in the nginx with the dist file created in stage 1(Angular Build)
 FROM nginx
-COPY --from=compile-image /app/dist/userRegistrationWeb /usr/share/nginx/html
+ARG BASE_HREF=/participant-manager
+COPY --from=compile-image /app/dist/userRegistrationWeb /usr/share/nginx/html${BASE_HREF}

--- a/participant-manager/src/environments/environment.prod.ts
+++ b/participant-manager/src/environments/environment.prod.ts
@@ -11,8 +11,9 @@ export const environment = {
     'https://<BASE_URL>/auth-server/callback',
   hydraClientId: '<AUTH_SERVER_CLIENT_ID>',
   appVersion: 'v0.1',
-  termsPageTitle: 'terms title goes here',
-  termsPageDescription: 'terms description goes here',
-  aboutPageTitle: 'about page title goes here',
-  aboutPageDescription: 'about page description goes here',
+  termsPageTitle: 'Terms title goes here',
+  termsPageDescription: 'Terms description goes here',
+  aboutPageTitle: 'About page title goes here',
+  aboutPageDescription: 'About page description goes here',
+  copyright: 'Copyright 2020 Google LLC.',
 };

--- a/participant-manager/src/environments/environment.prod.ts
+++ b/participant-manager/src/environments/environment.prod.ts
@@ -3,17 +3,16 @@ export const environment = {
   production: true,
   // remove http/https to appear relative. xsrf-token skips absolute paths.
   participantManagerDatastoreUrl:
-    '//fda-mystudies.domain.com/participant-manager-datastore',
+    '//<BASE_URL>/participant-manager-datastore',
   baseHref: '/participant-manager/',
-  hydraLoginUrl: 'https://fda-mystudies.domain.com/oauth2/auth',
-  authServerUrl: 'https://fda-mystudies.domain.com/auth-server',
+  hydraLoginUrl: 'https://<BASE_URL>/oauth2/auth',
+  authServerUrl: 'https://<BASE_URL>/auth-server',
   authServerRedirectUrl:
-    'https://fda-mystudies.domain.com/auth-server/callback',
-  hydraClientId: 'MYSTUDIES_OAUTH_CLIENT',
+    'https://<BASE_URL>/auth-server/callback',
+  hydraClientId: '<AUTH_SERVER_CLIENT_ID>',
   appVersion: 'v0.1',
-  termsPageTitle: 'Terms title goes here',
-  termsPageDescription: 'Terms description goes here',
-  aboutPageTitle: 'About page title goes here',
-  aboutPageDescription: 'About page description goes here',
-  copyright: 'Copyright 2020 Google LLC.',
+  termsPageTitle: 'terms title goes here',
+  termsPageDescription: 'terms description goes here',
+  aboutPageTitle: 'about page title goes here',
+  aboutPageDescription: 'about page description goes here',
 };

--- a/participant-manager/tf-deployment.yaml
+++ b/participant-manager/tf-deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: participant-manager
-        image: gcr.io/fda-mystudies-dev-apps/participant-manager:latest
+        image: gcr.io/<PREFIX>-<ENV>-apps/participant-manager:latest
         ports:
         - containerPort: 80
         readinessProbe:

--- a/participant-manager/tf-service.yaml
+++ b/participant-manager/tf-service.yaml
@@ -16,4 +16,4 @@ spec:
   ports:
   - protocol: TCP
     port: 50000
-    targetPort: 8080
+    targetPort: 80

--- a/response-datastore/tf-deployment.yaml
+++ b/response-datastore/tf-deployment.yaml
@@ -71,7 +71,7 @@ spec:
             - name: STUDY_DATASTORE_URL
               value: "http://study-datastore-np:50000/study-datastore"
             - name: PARTICIPANT_ENROLL_DATASTORE_URL
-              value: "http://participant-enroll-datastore:50000/participant-enroll-datastore"
+              value: "http://participant-enroll-datastore-np:50000/participant-enroll-datastore"
             - name: HYDRA_ADMIN_URL
               value: "http://hydra-admin-np:50000"
             - name: SCIM_AUTH_URL

--- a/response-datastore/tf-deployment.yaml
+++ b/response-datastore/tf-deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: response-datastore
-          image: gcr.io/fda-mystudies-dev-apps/response-datastore:latest
+          image: gcr.io/<PREFIX>-<ENV>-apps/response-datastore:latest
           env:
             # DB ACCESS
             - name: DB_USER
@@ -71,7 +71,7 @@ spec:
             - name: STUDY_DATASTORE_URL
               value: "http://study-datastore-np:50000/study-datastore"
             - name: PARTICIPANT_ENROLL_DATASTORE_URL
-              value: "http://participant-enroll-datastore-np:50000/participant-enroll-datastore"
+              value: "http://participant-enroll-datastore:50000/participant-enroll-datastore"
             - name: HYDRA_ADMIN_URL
               value: "http://hydra-admin-np:50000"
             - name: SCIM_AUTH_URL
@@ -110,7 +110,7 @@ spec:
         - name: cloudsql-proxy
           image: gcr.io/cloudsql-docker/gce-proxy:latest
           command: ["/cloud_sql_proxy",
-            "-instances=fda-mystudies-dev-data:us-east1:mystudies=tcp:3306",
+            "-instances=<PREFIX>-<ENV>-data:<LOCATION>:mystudies=tcp:3306",
             "-credential_file=/secrets/gcloud_key/key.json"]
           volumeMounts:
           - name: gcloud-key-volume

--- a/study-builder/tf-deployment.yaml
+++ b/study-builder/tf-deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: study-builder
-          image: gcr.io/fda-mystudies-dev-apps/study-builder:latest
+          image: gcr.io/<PREFIX>-<ENV>-apps/study-builder:latest
           env:
             # DB ACCESS
             - name: DB_USER
@@ -126,7 +126,7 @@ spec:
         - name: cloudsql-proxy
           image: gcr.io/cloudsql-docker/gce-proxy:latest
           command: ["/cloud_sql_proxy",
-            "-instances=fda-mystudies-dev-data:us-east1:mystudies=tcp:3306",
+            "-instances=<PREFIX>-<ENV>-data:<LOCATION>:mystudies=tcp:3306",
             "-credential_file=/secrets/gcloud_key/key.json"]
           volumeMounts:
           - name: gcloud-key-volume

--- a/study-datastore/tf-deployment.yaml
+++ b/study-datastore/tf-deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: study-datastore
-          image: gcr.io/fda-mystudies-dev-apps/study-datastore:latest
+          image: gcr.io/<PREFIX>-<ENV>-apps/study-datastore:latest
           env:
             # DB ACCESS
             - name: DB_USER
@@ -118,7 +118,7 @@ spec:
         - name: cloudsql-proxy
           image: gcr.io/cloudsql-docker/gce-proxy:latest
           command: ["/cloud_sql_proxy",
-            "-instances=fda-mystudies-dev-data:us-east1:mystudies=tcp:3306",
+            "-instances=<PREFIX>-<ENV>-data:<LOCATION>:mystudies=tcp:3306",
             "-credential_file=/secrets/gcloud_key/key.json"]
           volumeMounts:
           - name: gcloud-key-volume


### PR DESCRIPTION
@moschetti 
- We have updated the Terraform deployment scripts similar to the master branch, so that it will be uniform between the branches and Going forward it will be easier to create new environment by using the develop branch in our system.

- We have removed access code from this script (create_study_builder_superadmin.sh), as this field is removed from the study builder database script (HPHC_My_Studies_DB_Create_Script.sql). Otherwise this script will fail to create the Super admin