### PR TITLE
Update main.tf

### DIFF
--- a/deployment/mystudies.hcl
+++ b/deployment/mystudies.hcl
@@ -940,7 +940,7 @@ data "google_container_cluster" "gke_cluster" {
 }
 
 provider "kubernetes" {
-  load_config_file       = false
+  #load_config_file       = false
   token                  = data.google_client_config.default.access_token
   host                   = data.google_container_cluster.gke_cluster.endpoint
   client_certificate     = base64decode(data.google_container_cluster.gke_cluster.master_auth.0.client_certificate)

--- a/deployment/terraform/kubernetes/main.tf
+++ b/deployment/terraform/kubernetes/main.tf
@@ -33,7 +33,7 @@ data "google_container_cluster" "gke_cluster" {
 }
 
 provider "kubernetes" {
-  load_config_file       = false
+  #load_config_file       = false
   token                  = data.google_client_config.default.access_token
   host                   = data.google_container_cluster.gke_cluster.endpoint
   client_certificate     = base64decode(data.google_container_cluster.gke_cluster.master_auth.0.client_certificate)

--- a/deployment/terraform/kubernetes/main.tf
+++ b/deployment/terraform/kubernetes/main.tf
@@ -33,7 +33,6 @@ data "google_container_cluster" "gke_cluster" {
 }
 
 provider "kubernetes" {
-  #load_config_file       = false
   token                  = data.google_client_config.default.access_token
   host                   = data.google_container_cluster.gke_cluster.endpoint
   client_certificate     = base64decode(data.google_container_cluster.gke_cluster.master_auth.0.client_certificate)

--- a/deployment/terraform/kubernetes/main.tf
+++ b/deployment/terraform/kubernetes/main.tf
@@ -33,6 +33,7 @@ data "google_container_cluster" "gke_cluster" {
 }
 
 provider "kubernetes" {
+  #load_config_file       = false
   token                  = data.google_client_config.default.access_token
   host                   = data.google_container_cluster.gke_cluster.endpoint
   client_certificate     = base64decode(data.google_container_cluster.gke_cluster.master_auth.0.client_certificate)


### PR DESCRIPTION
@moschetti 
- We have commented out the "load_config_file"  argument from the deployment/terraform/kubernetes/main.tf file to solve the below error
- This particular argument is deprecated from Kubernetes version 2.0.0

Note:
We have tested in our environment by commenting out this argument and it is successfully deployed and application also started working without any issues

-------------------------------------------
Error: Unsupported argument
  on main.tf line 36, in provider "kubernetes":
  36:   load_config_file       = false
An argument named "load_config_file" is not expected here
------------------------------------------------

- We have commented out the same argument even in the mystudies.hcl file otherwise this file will replace the value again on tfengine execution. if we are not doing this change  user will face above issue.