### PR TITLE
Update cloudbuild.yaml

### DIFF
--- a/participant-manager/cloudbuild.yaml
+++ b/participant-manager/cloudbuild.yaml
@@ -9,3 +9,4 @@ steps:
   dir: "participant-manager"
 
 images: ['gcr.io/$PROJECT_ID/participant-manager']
+timeout: 720s


### PR DESCRIPTION
@moschetti 
 We have seen participant manager is taking more time to build the application, so we have increased time out to 720sec in cloudbuild.yaml file. Please approve it

--This PR will avoid Time-out error in case if any network delay and we are increasing as a precaution
--This will not stop for further process 
