### PR TITLE
Update README.md

### DIFF
--- a/db-migration/README.md
+++ b/db-migration/README.md
@@ -103,7 +103,7 @@ VPC without the need for Authorized networks or for configuring SSL.
    `Instance connection name`
 
    ```
-   ./cloud_sql_proxy -instances=<{PREFIX}-{ENV}-data:{REGION}:mystudies>tcp:3306
+   ./cloud_sql_proxy -instances=<{PREFIX}-{ENV}-data:{REGION}:mystudies>=tcp:3306
    ```
 
 ### Data Migration Script Execution Setup:


### PR DESCRIPTION
@moschetti 
./cloud_sql_proxy -instances=<{PREFIX}-{ENV}-data:{REGION}:mystudies>=tcp:3306
In the above command '=" is missing before tcp
Please merge it

Note: we need to add some reference about the db migration script in the deployment readme file other wise user's will miss to execute the migration scripts