### PR TITLE
[v2.0.3] DB migration script execution failure fix for Participant Datastore

### DIFF
--- a/participant-datastore/consent-mgmt-module/consent-mgmt/src/main/resources/application.properties
+++ b/participant-datastore/consent-mgmt-module/consent-mgmt/src/main/resources/application.properties
@@ -21,7 +21,7 @@ spring.datasource.username=${DB_USER}
 spring.datasource.password=${DB_PASS}
 spring.jpa.database-platform=org.hibernate.dialect.MySQL5InnoDBDialect
 spring.jpa.show-sql=false
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=none
 
 # Refer https://docs.spring.io/spring-boot/docs/current/reference/html/appendix-application-properties.html#data-properties
 spring.datasource.type=com.zaxxer.hikari.HikariDataSource

--- a/response-datastore/response-server-service/src/main/resources/application.properties
+++ b/response-datastore/response-server-service/src/main/resources/application.properties
@@ -23,7 +23,7 @@ spring.datasource.password=${DB_PASS}
 spring.datasource.driverClassName=com.mysql.cj.jdbc.Driver
 spring.jpa.database-platform=org.hibernate.dialect.MySQL5InnoDBDialect
 spring.jpa.show-sql=true
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=none
 
 # Refer https://docs.spring.io/spring-boot/docs/current/reference/html/appendix-application-properties.html#data-properties   
 spring.datasource.type=com.zaxxer.hikari.HikariDataSource


### PR DESCRIPTION
Changed the _spring.jpa.hibernate.ddl-auto property_ to **none** to fix DB migration script execution failure. 

With the current value "**update**" hibernate manipulate the database schema at startup.