### PR TITLE
[v2.0.4] Issue 954 and 3324 fixes

### DIFF
--- a/study-builder/fdahpStudyDesigner/src/main/webapp/WEB-INF/view/changeExpiredPassword.jsp
+++ b/study-builder/fdahpStudyDesigner/src/main/webapp/WEB-INF/view/changeExpiredPassword.jsp
@@ -99,7 +99,7 @@
                 <input type="password" class="form-control input-field wow_input" id="oldPassword"
                        name=""
                        maxlength="14" data-minlength="8" placeholder="Previous password"
-                       data-error="Invalid old password." required
+                       data-error="Invalid previous password." required
                        autocomplete="off"/>
                 <div class="help-block with-errors"></div>
                 <input type="hidden" name="oldPassword" id="hideOldPass"/>

--- a/study-builder/fdahpStudyDesigner/src/main/webapp/WEB-INF/view/changeExpiredPassword.jsp
+++ b/study-builder/fdahpStudyDesigner/src/main/webapp/WEB-INF/view/changeExpiredPassword.jsp
@@ -77,16 +77,11 @@
     </form>
 
     <div id="lg-container" class="lg-container">
-      <div class="logout">
-        <div class="dis-line pull-right ml-md line34">
-          <a href="/studybuilder/sessionOut.do"
-             class="blue-link text-weight-normal text-uppercase">
-            <span class="white__text">sign Out</span>
-          </a>
-        </div>
-      </div>
       <div class="logo__space">
-        <img src="../images/logo/logo_innerScreens.png" alt=""/>
+        <a href="/studybuilder/sessionOut.do"
+             class="blue-link text-weight-normal text-uppercase">
+        	<img src="../images/logo/logo_landing_welcome.png" alt=""/>
+        </a>
       </div>
       <div class="pwdexp__container">
         <!--container-->
@@ -99,13 +94,11 @@
             <div>
               <div id="errMsg" class="error_msg">${errMsg}</div>
               <div id="sucMsg" class="suceess_msg">${sucMsg}</div>
-              <p class="white__text">Your password has expired. You need to reset your password to
-                proceed
-                further.</p>
+              <p class="white__text">Your password has expired. Please create a new password.</p>
               <div class="mb-lg form-group">
                 <input type="password" class="form-control input-field wow_input" id="oldPassword"
                        name=""
-                       maxlength="14" data-minlength="8" placeholder="Old Password"
+                       maxlength="14" data-minlength="8" placeholder="Previous password"
                        data-error="Invalid old password." required
                        autocomplete="off"/>
                 <div class="help-block with-errors"></div>
@@ -113,7 +106,7 @@
               </div>
               <div class="mb-lg form-group">
                 <input type="password" class="form-control input-field wow_input" id="password" name=""
-                       maxlength="14" data-minlength="8" placeholder="Password"
+                       maxlength="14" data-minlength="8" placeholder="New password"
                        data-error="Password is invalid"
                        required
                        pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!&quot;#$%&amp;'()*+,-.:;&lt;=&gt;?@[\]^_`{|}~])[A-Za-z\d!&quot;#$%&amp;'()*+,-.:;&lt;=&gt;?@[\]^_`{|}~]{8,14}"

--- a/study-builder/fdahpStudyDesigner/src/main/webapp/WEB-INF/view/loginPage.jsp
+++ b/study-builder/fdahpStudyDesigner/src/main/webapp/WEB-INF/view/loginPage.jsp
@@ -118,7 +118,7 @@
                 <div class="help-block with-errors red-txt"></div>
               </div>
               <div class="mb-lg form-group">
-                <button type="button" id="loginBtnId" class="btn lg-btn">SIGN IN</button>
+                <button type="button" id="loginBtnId" class="btn lg-btn">Sign in</button>
               </div>
               <div class="pb-md pt-xs">
                 <a id="forgot_pwd"
@@ -148,7 +148,7 @@
                 <div class="help-block with-errors red-txt"></div>
               </div>
               <div class="mb-lg">
-                <button type="submit" class="btn lg-btn" id="log-btn">SUBMIT</button>
+                <button type="submit" class="btn lg-btn" id="log-btn">Submit</button>
               </div>
               <div class="pt-xs">
                 <a id="login" class="gray-link white__text hover_text_white" href="javascript:void(0)">Back to sign in

--- a/study-builder/fdahpStudyDesigner/src/main/webapp/WEB-INF/view/userPasswordReset.jsp
+++ b/study-builder/fdahpStudyDesigner/src/main/webapp/WEB-INF/view/userPasswordReset.jsp
@@ -83,12 +83,11 @@
             <div id="sucMsg" class="suceess_msg">${sucMsg}</div>
             <c:if test="${not isInactiveUser && isValidToken}">
               <div>
-              <p class="white__text">Please set up your new password using
-                this form.</p>
+              <p class="white__text">Create new password</p>
               <div class="mb-lg form-group">
                 <input type="password" class="input-field wow_input"
                        id="password" tabindex="2" maxlength="64" data-minlength="8"
-                       placeholder="Password*" required
+                       placeholder="New password*" required
                        pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!&quot;#$%&amp;'()*+,-.:;&lt;=&gt;?@[\]^_`{|}~])[A-Za-z\d!&quot;#$%&amp;'()*+,-.:;&lt;=&gt;?@[\]^_`{|}~]{8,64}"
                        data-error="Password is invalid" autocomplete="off"/>
                 <div class="help-block with-errors red-txt"></div>


### PR DESCRIPTION
This PR contains the issue fixes for issue #954  and #3324  .

1. 3324 issue fixes:
==========
- Reset password screen logo changed.



2. 954 issue fixes:
==========
- Change top text to "Your password has expired. Please create a new password."
- Change top text box text to "Previous password"
- Change middle text box text to "New password"
- Change bottom text box text to "Confirm new password"
 
- The logo in the upper left corner does not link back to the main study builder landing page and the upper
       right link says "sign out" which is not correct because I'm not signed on this page - user should not be 
       signed in at this point and must be signed out instead and so we need not display sign out here either.
 
- The confirmation messages that appear after clicking "submit" are displayed for 1 or 2 seconds, 
      which is not enough time to read them.  - increase to 5 seconds.

- For the user initiated password reset screen, Give the page a title that says something like "Create new password" 
      Sometimes the Submit button is in all caps and other times it is in title case - should be Submit.

Above points are corrected.


