### PR TITLE
[v2.0.5]Wrong Error Message Displayed due to incorrect HTTP Status code

### DIFF
--- a/common-modules/common-service/src/main/java/com/google/cloud/healthcare/fdamystudies/common/ErrorCode.java
+++ b/common-modules/common-service/src/main/java/com/google/cloud/healthcare/fdamystudies/common/ErrorCode.java
@@ -203,9 +203,9 @@ public enum ErrorCode {
   ADMIN_NOT_FOUND(404, "EC_0042", HttpStatus.NOT_FOUND.toString(), "Admin user not found"),
 
   PENDING_CONFIRMATION(
-      403,
+      409,
       "EC_0043",
-      HttpStatus.BAD_REQUEST.toString(),
+      HttpStatus.CONFLICT.toString(),
       "Your account is pending activation. Please check your email for details and sign in to complete activation."),
 
   ACCOUNT_NOT_VERIFIED(


### PR DESCRIPTION
Wrong Error Message Displayed due to incorrect HTTP Status code. #3440 #3304 