### PR TITLE
[v2.0.6] Issue #3125, API documentation using swagger - Study Datastore

### DIFF
--- a/documentation/API/study-datastore/swagger.json
+++ b/documentation/API/study-datastore/swagger.json
@@ -1,0 +1,1659 @@
+{
+  "swagger" : "2.0",
+  "info" : {
+    "version" : "2.0.3",
+    "title" : "Study Meta Data",
+    "termsOfService" : "http://www.github.com/kongchen/swagger-maven-plugin",
+    "license" : {
+      "name" : "Apache 2.0",
+      "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "tags" : [ {
+    "name" : "Studies"
+  } ],
+  "schemes" : [ "http", "https" ],
+  "paths" : {
+    "/activity" : {
+      "get" : {
+        "tags" : [ "Studies" ],
+        "summary" : "Get an activity from list of activities available for a study using activity version",
+        "description" : "",
+        "operationId" : "studyActivityMetadata",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "studyId",
+          "in" : "query",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "activityId",
+          "in" : "query",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "activityVersion",
+          "in" : "query",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "102" : {
+            "description" : "Invalid input."
+          },
+          "103" : {
+            "description" : "No records found"
+          },
+          "104" : {
+            "description" : "UNKNOWN"
+          },
+          "200" : {
+            "description" : "Successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/QuestionnaireActivityMetaDataResponse"
+            }
+          }
+        }
+      }
+    },
+    "/activityList" : {
+      "get" : {
+        "tags" : [ "Studies" ],
+        "summary" : "Get the list of activities that are available for a particular study",
+        "description" : "",
+        "operationId" : "studyActivityList",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "Authorization",
+          "in" : "header",
+          "required" : true,
+          "type" : "string",
+          "default" : ""
+        }, {
+          "name" : "studyId",
+          "in" : "query",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "102" : {
+            "description" : "Sorry, something went wrong. Please try again."
+          },
+          "103" : {
+            "description" : "No records found"
+          },
+          "104" : {
+            "description" : "UNKNOWN"
+          },
+          "200" : {
+            "description" : "Successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/ActivityResponse"
+            }
+          }
+        }
+      }
+    },
+    "/activityResponce" : {
+      "post" : {
+        "tags" : [ "Studies" ],
+        "summary" : "This API will save the activities response",
+        "description" : "",
+        "operationId" : "storeJsonResponseFile",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "body",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "Authorization",
+          "in" : "header",
+          "required" : true,
+          "type" : "string",
+          "default" : ""
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Successful operation"
+          },
+          "400" : {
+            "description" : "Invalid resource"
+          }
+        }
+      }
+    },
+    "/appUpdates" : {
+      "get" : {
+        "tags" : [ "Studies" ],
+        "summary" : "Get latest app updates using app version",
+        "description" : "",
+        "operationId" : "appUpdates",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "appVersion",
+          "in" : "query",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "Authorization",
+          "in" : "header",
+          "required" : true,
+          "type" : "string",
+          "default" : ""
+        } ],
+        "responses" : {
+          "102" : {
+            "description" : "Invalid input."
+          },
+          "104" : {
+            "description" : "UNKNOWN"
+          },
+          "200" : {
+            "description" : "Successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/AppUpdatesResponse"
+            }
+          }
+        }
+      }
+    },
+    "/consentDocument" : {
+      "get" : {
+        "tags" : [ "Studies" ],
+        "summary" : "Get the consent Document for a particular study based on the consent Version",
+        "description" : "",
+        "operationId" : "consentDocument",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "studyId",
+          "in" : "query",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "consentVersion",
+          "in" : "query",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "activityId",
+          "in" : "query",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "activityVersion",
+          "in" : "query",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "102" : {
+            "description" : "Invalid input."
+          },
+          "103" : {
+            "description" : "No records found"
+          },
+          "104" : {
+            "description" : "UNKNOWN"
+          },
+          "200" : {
+            "description" : "Successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/ConsentDocumentResponse"
+            }
+          }
+        }
+      }
+    },
+    "/eligibilityConsent" : {
+      "get" : {
+        "tags" : [ "Studies" ],
+        "summary" : "Get the eligibility method configured for a particular study",
+        "description" : "",
+        "operationId" : "eligibilityConsentMetadata",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "studyId",
+          "in" : "query",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "102" : {
+            "description" : "Invalid input."
+          },
+          "103" : {
+            "description" : "No records found"
+          },
+          "104" : {
+            "description" : "UNKNOWN"
+          },
+          "200" : {
+            "description" : "Successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/EligibilityConsentResponse"
+            }
+          }
+        }
+      }
+    },
+    "/gatewayInfo" : {
+      "get" : {
+        "tags" : [ "Studies" ],
+        "summary" : "Get the platform from the provided authorization credentials and fetch based on the platform",
+        "description" : "",
+        "operationId" : "gatewayAppResourcesInfo",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "Authorization",
+          "in" : "header",
+          "required" : true,
+          "type" : "string",
+          "default" : ""
+        } ],
+        "responses" : {
+          "103" : {
+            "description" : "No records found"
+          },
+          "104" : {
+            "description" : "UNKNOWN"
+          },
+          "200" : {
+            "description" : "Successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/GatewayInfoResponse"
+            }
+          }
+        }
+      }
+    },
+    "/healthCheck" : {
+      "get" : {
+        "tags" : [ "Studies" ],
+        "summary" : "Provides an indication about the health of the service",
+        "description" : "Default response codes 400 and 401 are not applicable for this operation",
+        "operationId" : "healthCheck",
+        "responses" : {
+          "200" : {
+            "description" : "Service is Up and Running",
+            "schema" : {
+              "type" : "string"
+            }
+          }
+        }
+      }
+    },
+    "/notifications" : {
+      "get" : {
+        "tags" : [ "Studies" ],
+        "summary" : "Get list of notifications of a particular app using appId",
+        "description" : "",
+        "operationId" : "notifications",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "skip",
+          "in" : "query",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "Authorization",
+          "in" : "header",
+          "required" : true,
+          "type" : "string",
+          "default" : ""
+        }, {
+          "name" : "applicationId",
+          "in" : "header",
+          "required" : true,
+          "type" : "string",
+          "default" : ""
+        } ],
+        "responses" : {
+          "102" : {
+            "description" : "Invalid input."
+          },
+          "103" : {
+            "description" : "No records found"
+          },
+          "104" : {
+            "description" : "UNKNOWN"
+          },
+          "200" : {
+            "description" : "Successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/NotificationsResponse"
+            }
+          }
+        }
+      }
+    },
+    "/resources" : {
+      "get" : {
+        "tags" : [ "Studies" ],
+        "summary" : "Get all the resources available for a partucular study",
+        "description" : "",
+        "operationId" : "resourcesForStudy",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "studyId",
+          "in" : "query",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "102" : {
+            "description" : "Invalid input."
+          },
+          "103" : {
+            "description" : "No records found"
+          },
+          "104" : {
+            "description" : "UNKNOWN"
+          },
+          "200" : {
+            "description" : "Successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/ResourcesResponse"
+            }
+          }
+        }
+      }
+    },
+    "/study" : {
+      "get" : {
+        "tags" : [ "Studies" ],
+        "summary" : "Get basic information of study using study Id",
+        "description" : "",
+        "operationId" : "study",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "studyId",
+          "in" : "query",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "102" : {
+            "description" : "Invalid input."
+          },
+          "200" : {
+            "description" : "Successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/StudyResponse"
+            }
+          }
+        }
+      }
+    },
+    "/studyDashboard" : {
+      "get" : {
+        "tags" : [ "Studies" ],
+        "summary" : "Get charts and statistics data for a particular study to display in mobile app dashboard",
+        "description" : "",
+        "operationId" : "studyDashboardInfo",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "studyId",
+          "in" : "query",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "102" : {
+            "description" : "Invalid input."
+          },
+          "103" : {
+            "description" : "No records found"
+          },
+          "104" : {
+            "description" : "UNKNOWN"
+          },
+          "200" : {
+            "description" : "Successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/StudyDashboardResponse"
+            }
+          }
+        }
+      }
+    },
+    "/studyInfo" : {
+      "get" : {
+        "tags" : [ "Studies" ],
+        "summary" : "Get the study information for a particular study",
+        "description" : "",
+        "operationId" : "studyInfo",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "studyId",
+          "in" : "query",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "102" : {
+            "description" : "Invalid input."
+          },
+          "103" : {
+            "description" : "No records found"
+          },
+          "104" : {
+            "description" : "UNKNOWN"
+          },
+          "200" : {
+            "description" : "Successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/StudyInfoResponse"
+            }
+          }
+        }
+      }
+    },
+    "/studyList" : {
+      "get" : {
+        "tags" : [ "Studies" ],
+        "summary" : "Get list of studies based on applicationId",
+        "description" : "",
+        "operationId" : "studyList",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "Authorization",
+          "in" : "header",
+          "required" : true,
+          "type" : "string",
+          "default" : ""
+        }, {
+          "name" : "applicationId",
+          "in" : "header",
+          "required" : true,
+          "type" : "string",
+          "default" : ""
+        } ],
+        "responses" : {
+          "103" : {
+            "description" : "No records found"
+          },
+          "104" : {
+            "description" : "UNKNOWN"
+          },
+          "200" : {
+            "description" : "Successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/StudyResponse"
+            }
+          }
+        }
+      }
+    },
+    "/studyUpdates" : {
+      "get" : {
+        "tags" : [ "Studies" ],
+        "summary" : "Get latest study updates using study Id and study version",
+        "description" : "",
+        "operationId" : "studyUpdates",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "studyId",
+          "in" : "query",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "studyVersion",
+          "in" : "query",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "102" : {
+            "description" : "Sorry, something went wrong. Please try again."
+          },
+          "103" : {
+            "description" : "NODATA"
+          },
+          "200" : {
+            "description" : "Successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/StudyUpdatesResponse"
+            }
+          }
+        }
+      }
+    },
+    "/termsPolicy" : {
+      "get" : {
+        "tags" : [ "Studies" ],
+        "summary" : "Get terms and policy details of application",
+        "description" : "",
+        "operationId" : "termsPolicy",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "103" : {
+            "description" : "No records found"
+          },
+          "104" : {
+            "description" : "UNKNOWN"
+          },
+          "200" : {
+            "description" : "Successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/TermsPolicyResponse"
+            }
+          }
+        }
+      }
+    },
+    "/updateAppVersion" : {
+      "post" : {
+        "tags" : [ "Studies" ],
+        "summary" : "Update app version details like app version, OS type, custom study ID etc.",
+        "description" : "",
+        "operationId" : "updateAppVersionDetails",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "body",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "102" : {
+            "description" : "Invalid input."
+          },
+          "200" : {
+            "description" : "Successful operation"
+          }
+        }
+      }
+    },
+    "/validateEnrollmentToken" : {
+      "get" : {
+        "tags" : [ "Studies" ],
+        "summary" : "This API will validate the Enrollment Token and return the response",
+        "description" : "",
+        "operationId" : "validateEnrollmentToken",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "token",
+          "in" : "query",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "102" : {
+            "description" : "Invalid input."
+          },
+          "200" : {
+            "description" : "Successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/EnrollmentTokenResponse"
+            }
+          }
+        }
+      }
+    },
+    "/versionInfo" : {
+      "get" : {
+        "tags" : [ "Studies" ],
+        "summary" : "Get the latest app (Android and IOS) version using application ID",
+        "description" : "",
+        "operationId" : "getAppVersionInfo",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "applicationId",
+          "in" : "header",
+          "required" : true,
+          "type" : "string",
+          "default" : ""
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/AppVersionInfoBean"
+            }
+          },
+          "400" : {
+            "description" : "Invalid resource"
+          },
+          "404" : {
+            "description" : "Details not found"
+          }
+        }
+      }
+    }
+  },
+  "definitions" : {
+    "ActivitiesBean" : {
+      "type" : "object",
+      "properties" : {
+        "activityId" : {
+          "type" : "string"
+        },
+        "activityVersion" : {
+          "type" : "string"
+        },
+        "title" : {
+          "type" : "string"
+        },
+        "type" : {
+          "type" : "string"
+        },
+        "startTime" : {
+          "type" : "string"
+        },
+        "endTime" : {
+          "type" : "string"
+        },
+        "branching" : {
+          "type" : "boolean",
+          "default" : false
+        },
+        "isLaunchStudy" : {
+          "type" : "boolean",
+          "default" : false
+        },
+        "isStudyLifeTime" : {
+          "type" : "boolean",
+          "default" : false
+        },
+        "lastModified" : {
+          "type" : "string"
+        },
+        "state" : {
+          "type" : "string"
+        },
+        "taskSubType" : {
+          "type" : "string"
+        },
+        "schedulingType" : {
+          "type" : "string"
+        },
+        "anchorDate" : {
+          "$ref" : "#/definitions/ActivityAnchorDateBean"
+        },
+        "frequency" : {
+          "$ref" : "#/definitions/ActivityFrequencyBean"
+        }
+      }
+    },
+    "ActivityAnchorDateBean" : {
+      "type" : "object",
+      "properties" : {
+        "sourceType" : {
+          "type" : "string"
+        },
+        "sourceActivityId" : {
+          "type" : "string"
+        },
+        "sourceKey" : {
+          "type" : "string"
+        },
+        "sourceFormKey" : {
+          "type" : "string"
+        },
+        "start" : {
+          "$ref" : "#/definitions/ActivityAnchorStartBean"
+        },
+        "end" : {
+          "$ref" : "#/definitions/ActivityAnchorEndBean"
+        }
+      }
+    },
+    "ActivityAnchorEndBean" : {
+      "type" : "object",
+      "properties" : {
+        "anchorDays" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "repeatInterval" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "time" : {
+          "type" : "string"
+        }
+      }
+    },
+    "ActivityAnchorStartBean" : {
+      "type" : "object",
+      "properties" : {
+        "anchorDays" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "dayOfWeek" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "dateOfMonth" : {
+          "type" : "string"
+        },
+        "time" : {
+          "type" : "string"
+        }
+      }
+    },
+    "ActivityFrequencyAnchorRunsBean" : {
+      "type" : "object",
+      "properties" : {
+        "startDays" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "endDays" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "time" : {
+          "type" : "string"
+        }
+      }
+    },
+    "ActivityFrequencyBean" : {
+      "type" : "object",
+      "properties" : {
+        "type" : {
+          "type" : "string"
+        },
+        "runs" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ActivityFrequencyScheduleBean"
+          }
+        },
+        "anchorRuns" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ActivityFrequencyAnchorRunsBean"
+          }
+        }
+      }
+    },
+    "ActivityFrequencyScheduleBean" : {
+      "type" : "object",
+      "properties" : {
+        "startTime" : {
+          "type" : "string"
+        },
+        "endTime" : {
+          "type" : "string"
+        }
+      }
+    },
+    "ActivityMetadataBean" : {
+      "type" : "object",
+      "properties" : {
+        "studyId" : {
+          "type" : "string"
+        },
+        "activityId" : {
+          "type" : "string"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "version" : {
+          "type" : "string"
+        },
+        "lastModified" : {
+          "type" : "string"
+        },
+        "startDate" : {
+          "type" : "string"
+        },
+        "endDate" : {
+          "type" : "string"
+        }
+      }
+    },
+    "ActivityResponse" : {
+      "type" : "object",
+      "properties" : {
+        "message" : {
+          "type" : "string"
+        },
+        "activities" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ActivitiesBean"
+          }
+        }
+      }
+    },
+    "AnchorDateBean" : {
+      "type" : "object",
+      "properties" : {
+        "type" : {
+          "type" : "string"
+        },
+        "questionInfo" : {
+          "$ref" : "#/definitions/QuestionInfoBean"
+        }
+      }
+    },
+    "AppUpdatesResponse" : {
+      "type" : "object",
+      "properties" : {
+        "message" : {
+          "type" : "string"
+        },
+        "forceUpdate" : {
+          "type" : "boolean",
+          "default" : false
+        },
+        "currentVersion" : {
+          "type" : "string"
+        }
+      }
+    },
+    "AppVersionInfoBean" : {
+      "type" : "object",
+      "properties" : {
+        "android" : {
+          "$ref" : "#/definitions/DeviceVersion"
+        },
+        "ios" : {
+          "$ref" : "#/definitions/DeviceVersion"
+        }
+      }
+    },
+    "ChartDataSourceBean" : {
+      "type" : "object",
+      "properties" : {
+        "type" : {
+          "type" : "string"
+        },
+        "key" : {
+          "type" : "string"
+        },
+        "activity" : {
+          "$ref" : "#/definitions/DashboardActivityBean"
+        },
+        "timeRangeType" : {
+          "type" : "string"
+        },
+        "startTime" : {
+          "type" : "string"
+        },
+        "endTime" : {
+          "type" : "string"
+        }
+      }
+    },
+    "ChartsBean" : {
+      "type" : "object",
+      "properties" : {
+        "title" : {
+          "type" : "string"
+        },
+        "displayName" : {
+          "type" : "string"
+        },
+        "type" : {
+          "type" : "string"
+        },
+        "configuration" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "scrollable" : {
+          "type" : "boolean",
+          "default" : false
+        },
+        "dataSource" : {
+          "$ref" : "#/definitions/ChartDataSourceBean"
+        }
+      }
+    },
+    "ComprehensionDetailsBean" : {
+      "type" : "object",
+      "properties" : {
+        "passScore" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "questions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/QuestionnaireActivityStepsBean"
+          }
+        },
+        "correctAnswers" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/CorrectAnswersBean"
+          }
+        }
+      }
+    },
+    "ConsentBean" : {
+      "type" : "object",
+      "properties" : {
+        "type" : {
+          "type" : "string"
+        },
+        "title" : {
+          "type" : "string"
+        },
+        "text" : {
+          "type" : "string"
+        },
+        "description" : {
+          "type" : "string"
+        },
+        "html" : {
+          "type" : "string"
+        },
+        "url" : {
+          "type" : "string"
+        },
+        "visualStep" : {
+          "type" : "boolean",
+          "default" : false
+        }
+      }
+    },
+    "ConsentDetailsBean" : {
+      "type" : "object",
+      "properties" : {
+        "version" : {
+          "type" : "string"
+        },
+        "visualScreens" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ConsentBean"
+          }
+        },
+        "comprehension" : {
+          "$ref" : "#/definitions/ComprehensionDetailsBean"
+        },
+        "sharing" : {
+          "$ref" : "#/definitions/SharingBean"
+        },
+        "review" : {
+          "$ref" : "#/definitions/ReviewBean"
+        }
+      }
+    },
+    "ConsentDocumentBean" : {
+      "type" : "object",
+      "properties" : {
+        "version" : {
+          "type" : "string"
+        },
+        "type" : {
+          "type" : "string"
+        },
+        "content" : {
+          "type" : "string"
+        }
+      }
+    },
+    "ConsentDocumentResponse" : {
+      "type" : "object",
+      "properties" : {
+        "message" : {
+          "type" : "string"
+        },
+        "consent" : {
+          "$ref" : "#/definitions/ConsentDocumentBean"
+        }
+      }
+    },
+    "CorrectAnswersBean" : {
+      "type" : "object",
+      "properties" : {
+        "key" : {
+          "type" : "string"
+        },
+        "answer" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "evaluation" : {
+          "type" : "string"
+        }
+      }
+    },
+    "DashboardActivityBean" : {
+      "type" : "object",
+      "properties" : {
+        "activityId" : {
+          "type" : "string"
+        },
+        "version" : {
+          "type" : "string"
+        }
+      }
+    },
+    "DashboardBean" : {
+      "type" : "object",
+      "properties" : {
+        "statistics" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/StatisticsBean"
+          }
+        },
+        "charts" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ChartsBean"
+          }
+        }
+      }
+    },
+    "DestinationBean" : {
+      "type" : "object",
+      "properties" : {
+        "condition" : {
+          "type" : "string"
+        },
+        "operator" : {
+          "type" : "string"
+        },
+        "destination" : {
+          "type" : "string"
+        }
+      }
+    },
+    "DeviceVersion" : {
+      "type" : "object",
+      "properties" : {
+        "latestVersion" : {
+          "type" : "string"
+        },
+        "forceUpdate" : {
+          "type" : "string"
+        }
+      }
+    },
+    "EligibilityBean" : {
+      "type" : "object",
+      "properties" : {
+        "type" : {
+          "type" : "string"
+        },
+        "tokenTitle" : {
+          "type" : "string"
+        },
+        "test" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/QuestionnaireActivityStepsBean"
+          }
+        },
+        "correctAnswers" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "object"
+            }
+          }
+        }
+      }
+    },
+    "EligibilityConsentResponse" : {
+      "type" : "object",
+      "properties" : {
+        "message" : {
+          "type" : "string"
+        },
+        "eligibility" : {
+          "$ref" : "#/definitions/EligibilityBean"
+        },
+        "consent" : {
+          "$ref" : "#/definitions/ConsentDetailsBean"
+        }
+      }
+    },
+    "EnrollmentTokenResponse" : {
+      "type" : "object",
+      "properties" : {
+        "message" : {
+          "type" : "string"
+        }
+      }
+    },
+    "GatewayInfoResourceBean" : {
+      "type" : "object",
+      "properties" : {
+        "resourcesId" : {
+          "type" : "string"
+        },
+        "title" : {
+          "type" : "string"
+        },
+        "type" : {
+          "type" : "string"
+        },
+        "content" : {
+          "type" : "string"
+        }
+      }
+    },
+    "GatewayInfoResponse" : {
+      "type" : "object",
+      "properties" : {
+        "message" : {
+          "type" : "string"
+        },
+        "info" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/InfoBean"
+          }
+        },
+        "resources" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/GatewayInfoResourceBean"
+          }
+        }
+      }
+    },
+    "InfoBean" : {
+      "type" : "object",
+      "properties" : {
+        "type" : {
+          "type" : "string"
+        },
+        "image" : {
+          "type" : "string"
+        },
+        "title" : {
+          "type" : "string"
+        },
+        "text" : {
+          "type" : "string"
+        },
+        "videoLink" : {
+          "type" : "string"
+        }
+      }
+    },
+    "NotificationsBean" : {
+      "type" : "object",
+      "properties" : {
+        "notificationId" : {
+          "type" : "string"
+        },
+        "type" : {
+          "type" : "string"
+        },
+        "subtype" : {
+          "type" : "string"
+        },
+        "studyId" : {
+          "type" : "string"
+        },
+        "audience" : {
+          "type" : "string"
+        },
+        "title" : {
+          "type" : "string"
+        },
+        "message" : {
+          "type" : "string"
+        },
+        "date" : {
+          "type" : "string"
+        }
+      }
+    },
+    "NotificationsResponse" : {
+      "type" : "object",
+      "properties" : {
+        "message" : {
+          "type" : "string"
+        },
+        "notifications" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/NotificationsBean"
+          }
+        }
+      }
+    },
+    "QuestionInfoBean" : {
+      "type" : "object",
+      "properties" : {
+        "activityId" : {
+          "type" : "string"
+        },
+        "activityVersion" : {
+          "type" : "string"
+        },
+        "key" : {
+          "type" : "string"
+        }
+      }
+    },
+    "QuestionnaireActivityMetaDataResponse" : {
+      "type" : "object",
+      "properties" : {
+        "message" : {
+          "type" : "string"
+        },
+        "activity" : {
+          "$ref" : "#/definitions/QuestionnaireActivityStructureBean"
+        }
+      }
+    },
+    "QuestionnaireActivityStepsBean" : {
+      "type" : "object",
+      "properties" : {
+        "type" : {
+          "type" : "string"
+        },
+        "resultType" : {
+          "type" : "string"
+        },
+        "key" : {
+          "type" : "string"
+        },
+        "title" : {
+          "type" : "string"
+        },
+        "text" : {
+          "type" : "string"
+        },
+        "skippable" : {
+          "type" : "boolean",
+          "default" : false
+        },
+        "groupName" : {
+          "type" : "string"
+        },
+        "repeatable" : {
+          "type" : "boolean",
+          "default" : false
+        },
+        "repeatableText" : {
+          "type" : "string"
+        },
+        "destinations" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/DestinationBean"
+          }
+        },
+        "healthDataKey" : {
+          "type" : "string"
+        },
+        "format" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "steps" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/QuestionnaireStepsBean"
+          }
+        },
+        "options" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "QuestionnaireActivityStructureBean" : {
+      "type" : "object",
+      "properties" : {
+        "type" : {
+          "type" : "string"
+        },
+        "metadata" : {
+          "$ref" : "#/definitions/ActivityMetadataBean"
+        },
+        "steps" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/QuestionnaireActivityStepsBean"
+          }
+        }
+      }
+    },
+    "QuestionnaireStepsBean" : {
+      "type" : "object",
+      "properties" : {
+        "type" : {
+          "type" : "string"
+        },
+        "resultType" : {
+          "type" : "string"
+        },
+        "key" : {
+          "type" : "string"
+        },
+        "title" : {
+          "type" : "string"
+        },
+        "text" : {
+          "type" : "string"
+        },
+        "skippable" : {
+          "type" : "boolean",
+          "default" : false
+        },
+        "groupName" : {
+          "type" : "string"
+        },
+        "repeatable" : {
+          "type" : "boolean",
+          "default" : false
+        },
+        "repeatableText" : {
+          "type" : "string"
+        },
+        "destinations" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/DestinationBean"
+          }
+        },
+        "healthDataKey" : {
+          "type" : "string"
+        },
+        "format" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        },
+        "options" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "ResourcesBean" : {
+      "type" : "object",
+      "properties" : {
+        "title" : {
+          "type" : "string"
+        },
+        "type" : {
+          "type" : "string"
+        },
+        "resourcesId" : {
+          "type" : "string"
+        },
+        "content" : {
+          "type" : "string"
+        },
+        "audience" : {
+          "type" : "string"
+        },
+        "notificationText" : {
+          "type" : "string"
+        },
+        "availability" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
+    "ResourcesResponse" : {
+      "type" : "object",
+      "properties" : {
+        "message" : {
+          "type" : "string"
+        },
+        "resources" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ResourcesBean"
+          }
+        }
+      }
+    },
+    "ReviewBean" : {
+      "type" : "object",
+      "properties" : {
+        "reviewHTML" : {
+          "type" : "string"
+        }
+      }
+    },
+    "SettingsBean" : {
+      "type" : "object",
+      "properties" : {
+        "enrolling" : {
+          "type" : "boolean",
+          "default" : false
+        },
+        "platform" : {
+          "type" : "string"
+        }
+      }
+    },
+    "SharingBean" : {
+      "type" : "object",
+      "properties" : {
+        "title" : {
+          "type" : "string"
+        },
+        "text" : {
+          "type" : "string"
+        },
+        "shortDesc" : {
+          "type" : "string"
+        },
+        "longDesc" : {
+          "type" : "string"
+        },
+        "learnMore" : {
+          "type" : "string"
+        },
+        "allowWithoutSharing" : {
+          "type" : "boolean",
+          "default" : false
+        }
+      }
+    },
+    "StatisticsBean" : {
+      "type" : "object",
+      "properties" : {
+        "title" : {
+          "type" : "string"
+        },
+        "displayName" : {
+          "type" : "string"
+        },
+        "statType" : {
+          "type" : "string"
+        },
+        "unit" : {
+          "type" : "string"
+        },
+        "calculation" : {
+          "type" : "string"
+        },
+        "dataSource" : {
+          "$ref" : "#/definitions/StatisticsDataSourceBean"
+        }
+      }
+    },
+    "StatisticsDataSourceBean" : {
+      "type" : "object",
+      "properties" : {
+        "type" : {
+          "type" : "string"
+        },
+        "key" : {
+          "type" : "string"
+        },
+        "activity" : {
+          "$ref" : "#/definitions/DashboardActivityBean"
+        }
+      }
+    },
+    "StudyBean" : {
+      "type" : "object",
+      "properties" : {
+        "studyId" : {
+          "type" : "string"
+        },
+        "studyVersion" : {
+          "type" : "string"
+        },
+        "title" : {
+          "type" : "string"
+        },
+        "category" : {
+          "type" : "string"
+        },
+        "sponsorName" : {
+          "type" : "string"
+        },
+        "tagline" : {
+          "type" : "string"
+        },
+        "status" : {
+          "type" : "string"
+        },
+        "logo" : {
+          "type" : "string"
+        },
+        "settings" : {
+          "$ref" : "#/definitions/SettingsBean"
+        }
+      }
+    },
+    "StudyDashboardResponse" : {
+      "type" : "object",
+      "properties" : {
+        "message" : {
+          "type" : "string"
+        },
+        "dashboard" : {
+          "$ref" : "#/definitions/DashboardBean"
+        }
+      }
+    },
+    "StudyInfoResponse" : {
+      "type" : "object",
+      "properties" : {
+        "message" : {
+          "type" : "string"
+        },
+        "studyWebsite" : {
+          "type" : "string"
+        },
+        "info" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/InfoBean"
+          }
+        },
+        "anchorDate" : {
+          "$ref" : "#/definitions/AnchorDateBean"
+        }
+      }
+    },
+    "StudyResponse" : {
+      "type" : "object",
+      "properties" : {
+        "message" : {
+          "type" : "string"
+        },
+        "studies" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/StudyBean"
+          }
+        }
+      }
+    },
+    "StudyUpdatesBean" : {
+      "type" : "object",
+      "properties" : {
+        "consent" : {
+          "type" : "boolean",
+          "default" : false
+        },
+        "activities" : {
+          "type" : "boolean",
+          "default" : false
+        },
+        "resources" : {
+          "type" : "boolean",
+          "default" : false
+        },
+        "info" : {
+          "type" : "boolean",
+          "default" : false
+        },
+        "status" : {
+          "type" : "string"
+        }
+      }
+    },
+    "StudyUpdatesResponse" : {
+      "type" : "object",
+      "properties" : {
+        "message" : {
+          "type" : "string"
+        },
+        "updates" : {
+          "$ref" : "#/definitions/StudyUpdatesBean"
+        },
+        "currentVersion" : {
+          "type" : "string"
+        }
+      }
+    },
+    "TermsPolicyResponse" : {
+      "type" : "object",
+      "properties" : {
+        "message" : {
+          "type" : "string"
+        },
+        "terms" : {
+          "type" : "string"
+        },
+        "privacy" : {
+          "type" : "string"
+        }
+      }
+    }
+  }
+}

--- a/study-datastore/pom.xml
+++ b/study-datastore/pom.xml
@@ -54,13 +54,18 @@
     <dependency>
       <groupId>javax.ws.rs</groupId>
       <artifactId>javax.ws.rs-api</artifactId>
-      <version>2.0-m01</version>
+      <version>2.0</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.jackson</groupId>
       <artifactId>jackson-jaxrs</artifactId>
       <version>1.9.13</version>
     </dependency>
+    <dependency>
+	  <groupId>com.fasterxml.jackson.jaxrs</groupId>
+	  <artifactId>jackson-jaxrs-json-provider</artifactId>
+	  <version>2.3.3</version>
+	</dependency>
     <dependency>
       <groupId>org.apache.ibatis</groupId>
       <artifactId>ibatis-sqlmap</artifactId>
@@ -82,42 +87,59 @@
       <artifactId>javax.persistence</artifactId>
       <version>2.1.0</version>
     </dependency>
+    
+	<dependency>
+	  <groupId>org.glassfish.jersey.containers</groupId>
+	  <artifactId>jersey-container-servlet</artifactId>
+	  <version>2.6</version>
+	</dependency>
+	<dependency>
+	  <groupId>org.glassfish.jersey.bundles</groupId>
+	  <artifactId>jaxrs-ri</artifactId>
+	  <version>2.6</version>
+	</dependency>
 
-    <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-core</artifactId>
-      <version>1.18.1</version>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-bundle</artifactId>
-      <version>1.18.1</version>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-server</artifactId>
-      <version>1.18.1</version>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-json</artifactId>
-      <version>1.18.1</version>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-client</artifactId>
-      <version>1.18.1</version>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-fastinfoset</artifactId>
-      <version>1.18.1</version>
-    </dependency>
+	<dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-annotations</artifactId>
+      <version>1.5.0</version>
+	</dependency>
+	<dependency>
+	  <groupId>io.swagger</groupId>
+	  <artifactId>swagger-jaxrs</artifactId>
+	  <version>1.5.0</version>
+	</dependency>
+	<dependency>
+	  <groupId>io.swagger</groupId>
+	  <artifactId>swagger-core</artifactId>
+	  <version>1.5.0</version>
+	</dependency>
+	<dependency>
+	  <groupId>io.swagger</groupId>
+	  <artifactId>swagger-models</artifactId>
+	  <version>1.5.0</version>
+	</dependency>
+	<dependency>
+	  <groupId>io.swagger</groupId>
+	  <artifactId>swagger-jersey2-jaxrs</artifactId>
+	  <version>1.5.0</version>
+	</dependency>
+	<dependency>
+	  <groupId>com.google.guava</groupId>
+	  <artifactId>guava</artifactId>
+	  <version>18.0</version>
+	</dependency>
 
+	<dependency>
+	  <groupId>javax.mail</groupId>
+	  <artifactId>mail</artifactId>
+	  <version>1.4</version>
+	</dependency>
     <dependency>
-      <groupId>javax.mail</groupId>
-      <artifactId>mail</artifactId>
-      <version>1.4</version>
+      <groupId>org.apache.tomcat</groupId>
+      <artifactId>tomcat-servlet-api</artifactId>
+      <version>9.0.37</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
@@ -225,6 +247,37 @@
       <version>2.10.0</version>
     </dependency>
     <dependency>
+	  <groupId>com.fasterxml.jackson.core</groupId>
+	  <artifactId>jackson-annotations</artifactId>
+	  <version>2.10.0</version>
+	</dependency>
+	<dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+	  <artifactId>jackson-databind</artifactId>
+	  <version>2.10.0</version>
+	</dependency>
+       
+	<dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <version>2.3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
+      <version>2.3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.activation</groupId>
+      <artifactId>activation</artifactId>
+      <version>1.1.1</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-storage</artifactId>
       <version>1.96.0</version>
@@ -257,6 +310,41 @@
           <target>1.7</target>
         </configuration>
       </plugin>
-    </plugins>
-  </build>
+	  <plugin>
+         <groupId>com.github.kongchen</groupId>
+         <artifactId>swagger-maven-plugin</artifactId>
+         <version>3.1.0</version>
+         <configuration>
+           <apiSources>
+             <apiSource>
+               <springmvc>false</springmvc>
+               <schemes>http,https</schemes>
+               <locations>com.hphc.mystudies.service</locations>
+               <info>
+       			 <title>Study Meta Data</title>
+               	 <version>2.0.3</version>
+                 <termsOfService>
+                   http://www.github.com/kongchen/swagger-maven-plugin
+                 </termsOfService>
+	             <license>
+	               <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+	               <name>Apache 2.0</name>
+	             </license>
+			   </info>	
+               <swaggerDirectory>../../fda-mystudies/documentation/API/study-datastore</swaggerDirectory>
+             </apiSource>
+           </apiSources>
+         </configuration>
+         <executions>
+           <execution>
+             <phase>compile</phase>
+             <goals>
+               <goal>generate</goal>
+             </goals>
+           </execution>
+         </executions>
+	   </plugin>
+     </plugins>
+   </build>
+
 </project>

--- a/study-datastore/src/main/java/com/hphc/mystudies/bean/QuestionnaireStepsBean.java
+++ b/study-datastore/src/main/java/com/hphc/mystudies/bean/QuestionnaireStepsBean.java
@@ -28,7 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class QuestionnaireActivityStepsBean {
+public class QuestionnaireStepsBean {
 
   private String type = "";
 
@@ -53,8 +53,6 @@ public class QuestionnaireActivityStepsBean {
   private String healthDataKey = "";
 
   private Map<String, Object> format = new HashMap<>();
-
-  private List<QuestionnaireStepsBean> steps = new ArrayList<>();
 
   private String[] options = new String[0];
 
@@ -152,14 +150,6 @@ public class QuestionnaireActivityStepsBean {
 
   public void setFormat(Map<String, Object> format) {
     this.format = format;
-  }
-
-  public List<QuestionnaireStepsBean> getSteps() {
-    return steps;
-  }
-
-  public void setSteps(List<QuestionnaireStepsBean> steps) {
-    this.steps = steps;
   }
 
   public String[] getOptions() {

--- a/study-datastore/src/main/java/com/hphc/mystudies/dao/ActivityMetaDataDao.java
+++ b/study-datastore/src/main/java/com/hphc/mystudies/dao/ActivityMetaDataDao.java
@@ -39,6 +39,7 @@ import com.hphc.mystudies.bean.DestinationBean;
 import com.hphc.mystudies.bean.FetalKickCounterFormatBean;
 import com.hphc.mystudies.bean.QuestionnaireActivityMetaDataResponse;
 import com.hphc.mystudies.bean.QuestionnaireActivityStepsBean;
+import com.hphc.mystudies.bean.QuestionnaireStepsBean;
 import com.hphc.mystudies.bean.SpatialSpanMemoryFormatBean;
 import com.hphc.mystudies.bean.TowerOfHanoiFormatBean;
 import com.hphc.mystudies.bean.appendix.QuestionnaireActivityStructureBean;
@@ -1954,8 +1955,8 @@ public class ActivityMetaDataDao {
                           + StudyMetaDataConstants.QUESTIONAIRE_STEP_TYPE_FORM)
                       .toString());
           QuestionnaireActivityStepsBean formBean = new QuestionnaireActivityStepsBean();
-          List<QuestionnaireActivityStepsBean> formSteps = new ArrayList<>();
-          HashMap<Integer, QuestionnaireActivityStepsBean> formStepsMap = new HashMap<>();
+          List<QuestionnaireStepsBean> formSteps = new ArrayList<>();
+          HashMap<Integer, QuestionnaireStepsBean> formStepsMap = new HashMap<>();
 
           formBean.setType(StudyMetaDataConstants.QUESTIONAIRE_STEP_TYPE_FORM.toLowerCase());
           formBean.setResultType(StudyMetaDataConstants.RESULT_TYPE_GROUPED);
@@ -2003,8 +2004,7 @@ public class ActivityMetaDataDao {
                   .list();
           if ((formQuestionsList != null) && !formQuestionsList.isEmpty()) {
             for (QuestionsDto formQuestionDto : formQuestionsList) {
-              QuestionnaireActivityStepsBean formQuestionBean =
-                  new QuestionnaireActivityStepsBean();
+              QuestionnaireStepsBean formQuestionBean = new QuestionnaireStepsBean();
               formQuestionBean.setType(
                   StudyMetaDataConstants.QUESTIONAIRE_STEP_TYPE_QUESTION.toLowerCase());
               if (formQuestionDto.getResponseType() != null) {

--- a/study-datastore/src/main/java/com/hphc/mystudies/service/StudyMetaDataService.java
+++ b/study-datastore/src/main/java/com/hphc/mystudies/service/StudyMetaDataService.java
@@ -51,6 +51,11 @@ import com.hphc.mystudies.integration.StudyMetaDataOrchestration;
 import com.hphc.mystudies.util.StudyMetaDataConstants;
 import com.hphc.mystudies.util.StudyMetaDataEnum;
 import com.hphc.mystudies.util.StudyMetaDataUtil;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import java.util.HashMap;
 import java.util.List;
 import javax.servlet.ServletContext;
@@ -72,6 +77,10 @@ import org.slf4j.ext.XLogger;
 import org.slf4j.ext.XLoggerFactory;
 
 @Path("/")
+@Api(
+    tags = "Studies",
+    value = "Study Meta Data Services",
+    description = "Get study details for mobile app(Android and IOS)")
 public class StudyMetaDataService {
 
   private static final XLogger LOGGER =
@@ -86,12 +95,25 @@ public class StudyMetaDataService {
       new DashboardMetaDataOrchestration();
   AppMetaDataOrchestration appMetaDataOrchestration = new AppMetaDataOrchestration();
 
+  @ApiOperation(
+      value =
+          "Get the platform from the provided authorization credentials and fetch based on the platform")
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 103, message = StudyMetaDataConstants.NO_RECORD),
+        @ApiResponse(code = 104, message = ErrorCodes.UNKNOWN),
+        @ApiResponse(
+            code = 200,
+            message = "Successful operation",
+            response = GatewayInfoResponse.class)
+      })
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
   @Path("gatewayInfo")
   public Object gatewayAppResourcesInfo(
-      @HeaderParam("Authorization") String authorization,
+      @ApiParam(name = "Authorization", required = true) @HeaderParam("Authorization")
+          String authorization,
       @Context ServletContext context,
       @Context HttpServletResponse response) {
     LOGGER.entry("begin gatewayAppResourcesInfo()");
@@ -117,13 +139,22 @@ public class StudyMetaDataService {
     return gatewayInfo;
   }
 
+  @ApiOperation(value = "Get list of studies based on applicationId")
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 103, message = StudyMetaDataConstants.NO_RECORD),
+        @ApiResponse(code = 104, message = ErrorCodes.UNKNOWN),
+        @ApiResponse(code = 200, message = "Successful operation", response = StudyResponse.class)
+      })
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
   @Path("studyList")
   public Object studyList(
-      @HeaderParam("Authorization") String authorization,
-      @HeaderParam("applicationId") String applicationId,
+      @ApiParam(name = "Authorization", required = true) @HeaderParam("Authorization")
+          String authorization,
+      @ApiParam(name = "applicationId", required = true) @HeaderParam("applicationId")
+          String applicationId,
       @Context ServletContext context,
       @Context HttpServletResponse response) {
     LOGGER.entry("begin studyList()");
@@ -172,12 +203,23 @@ public class StudyMetaDataService {
     return studyResponse;
   }
 
+  @ApiOperation(value = "Get the eligibility method configured for a particular study")
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 102, message = StudyMetaDataConstants.INVALID_INPUT_ERROR_MSG),
+        @ApiResponse(code = 103, message = StudyMetaDataConstants.NO_RECORD),
+        @ApiResponse(code = 104, message = ErrorCodes.UNKNOWN),
+        @ApiResponse(
+            code = 200,
+            message = "Successful operation",
+            response = EligibilityConsentResponse.class)
+      })
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
   @Path("eligibilityConsent")
   public Object eligibilityConsentMetadata(
-      @QueryParam("studyId") String studyId,
+      @ApiParam(name = "studyId", required = true) @QueryParam("studyId") String studyId,
       @Context ServletContext context,
       @Context HttpServletResponse response) {
     LOGGER.entry("begin eligibilityConsentMetadata()");
@@ -227,15 +269,29 @@ public class StudyMetaDataService {
     return eligibilityConsentResponse;
   }
 
+  @ApiOperation(
+      value = "Get the consent Document for a particular study based on the consent Version")
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 102, message = StudyMetaDataConstants.INVALID_INPUT_ERROR_MSG),
+        @ApiResponse(code = 103, message = StudyMetaDataConstants.NO_RECORD),
+        @ApiResponse(code = 104, message = ErrorCodes.UNKNOWN),
+        @ApiResponse(
+            code = 200,
+            message = "Successful operation",
+            response = ConsentDocumentResponse.class)
+      })
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
   @Path("consentDocument")
   public Object consentDocument(
-      @QueryParam("studyId") String studyId,
-      @QueryParam("consentVersion") String consentVersion,
-      @QueryParam("activityId") String activityId,
-      @QueryParam("activityVersion") String activityVersion,
+      @ApiParam(name = "studyId", required = true) @QueryParam("studyId") String studyId,
+      @ApiParam(name = "consentVersion", required = true) @QueryParam("consentVersion")
+          String consentVersion,
+      @ApiParam(name = "activityId", required = true) @QueryParam("activityId") String activityId,
+      @ApiParam(name = "activityVersion", required = true) @QueryParam("activityVersion")
+          String activityVersion,
       @Context ServletContext context,
       @Context HttpServletResponse response) {
     LOGGER.entry("begin resourcesForStudy()");
@@ -287,12 +343,23 @@ public class StudyMetaDataService {
     return consentDocumentResponse;
   }
 
+  @ApiOperation(value = "Get all the resources available for a partucular study")
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 102, message = StudyMetaDataConstants.INVALID_INPUT_ERROR_MSG),
+        @ApiResponse(code = 103, message = StudyMetaDataConstants.NO_RECORD),
+        @ApiResponse(code = 104, message = ErrorCodes.UNKNOWN),
+        @ApiResponse(
+            code = 200,
+            message = "Successful operation",
+            response = ResourcesResponse.class)
+      })
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
   @Path("resources")
   public Object resourcesForStudy(
-      @QueryParam("studyId") String studyId,
+      @ApiParam(name = "studyId", required = true) @QueryParam("studyId") String studyId,
       @Context ServletContext context,
       @Context HttpServletResponse response) {
     LOGGER.entry("begin resourcesForStudy()");
@@ -342,12 +409,23 @@ public class StudyMetaDataService {
     return resourcesResponse;
   }
 
+  @ApiOperation(value = "Get the study information for a particular study")
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 102, message = StudyMetaDataConstants.INVALID_INPUT_ERROR_MSG),
+        @ApiResponse(code = 103, message = StudyMetaDataConstants.NO_RECORD),
+        @ApiResponse(code = 104, message = ErrorCodes.UNKNOWN),
+        @ApiResponse(
+            code = 200,
+            message = "Successful operation",
+            response = StudyInfoResponse.class)
+      })
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
   @Path("studyInfo")
   public Object studyInfo(
-      @QueryParam("studyId") String studyId,
+      @ApiParam(name = "studyId", required = true) @QueryParam("studyId") String studyId,
       @Context ServletContext context,
       @Context HttpServletResponse response) {
     LOGGER.entry("begin studyInfo()");
@@ -399,6 +477,7 @@ public class StudyMetaDataService {
                     propMap.get(StudyMetaDataConstants.FDA_SMD_STUDY_THUMBNAIL_PATH).trim()
                         + propMap.get(StudyMetaDataConstants.STUDY_DEFAULT_IMAGE),
                     StudyMetaDataConstants.SIGNED_URL_DURATION_IN_HOURS));
+
           } else {
             infoBean.setImage(
                 StudyMetaDataUtil.getSignedUrl(
@@ -423,13 +502,25 @@ public class StudyMetaDataService {
     return studyInfoResponse;
   }
 
+  @ApiOperation(value = "Get the list of activities that are available for a particular study")
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 102, message = StudyMetaDataConstants.INVALID_STUDY_ID),
+        @ApiResponse(code = 103, message = StudyMetaDataConstants.NO_RECORD),
+        @ApiResponse(code = 104, message = ErrorCodes.UNKNOWN),
+        @ApiResponse(
+            code = 200,
+            message = "Successful operation",
+            response = ActivityResponse.class)
+      })
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
   @Path("activityList")
   public Object studyActivityList(
-      @HeaderParam("Authorization") String authorization,
-      @QueryParam("studyId") String studyId,
+      @ApiParam(name = "Authorization", required = true) @HeaderParam("Authorization")
+          String authorization,
+      @ApiParam(name = "studyId", required = true) @QueryParam("studyId") String studyId,
       @Context ServletContext context,
       @Context HttpServletResponse response) {
     LOGGER.entry("begin studyActivityList()");
@@ -479,14 +570,28 @@ public class StudyMetaDataService {
     return activityResponse;
   }
 
+  @ApiOperation(
+      value =
+          "Get an activity from list of activities available for a study using activity version")
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 102, message = StudyMetaDataConstants.INVALID_INPUT_ERROR_MSG),
+        @ApiResponse(code = 103, message = StudyMetaDataConstants.NO_RECORD),
+        @ApiResponse(code = 104, message = ErrorCodes.UNKNOWN),
+        @ApiResponse(
+            code = 200,
+            message = "Successful operation",
+            response = QuestionnaireActivityMetaDataResponse.class)
+      })
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
   @Path("activity")
   public Object studyActivityMetadata(
-      @QueryParam("studyId") String studyId,
-      @QueryParam("activityId") String activityId,
-      @QueryParam("activityVersion") String activityVersion,
+      @ApiParam(name = "studyId", required = true) @QueryParam("studyId") String studyId,
+      @ApiParam(name = "activityId", required = true) @QueryParam("activityId") String activityId,
+      @ApiParam(name = "activityVersion", required = true) @QueryParam("activityVersion")
+          String activityVersion,
       @Context ServletContext context,
       @Context HttpServletResponse response) {
     LOGGER.entry("begin studyActivityMetadata()");
@@ -584,12 +689,25 @@ public class StudyMetaDataService {
     }
   }
 
+  @ApiOperation(
+      value =
+          "Get charts and statistics data for a particular study to display in mobile app dashboard")
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 102, message = StudyMetaDataConstants.INVALID_INPUT_ERROR_MSG),
+        @ApiResponse(code = 103, message = StudyMetaDataConstants.NO_RECORD),
+        @ApiResponse(code = 104, message = ErrorCodes.UNKNOWN),
+        @ApiResponse(
+            code = 200,
+            message = "Successful operation",
+            response = StudyDashboardResponse.class)
+      })
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
   @Path("studyDashboard")
   public Object studyDashboardInfo(
-      @QueryParam("studyId") String studyId,
+      @ApiParam(name = "studyId", required = true) @QueryParam("studyId") String studyId,
       @Context ServletContext context,
       @Context HttpServletResponse response) {
     LOGGER.entry("begin studyDashboardInfo()");
@@ -639,6 +757,16 @@ public class StudyMetaDataService {
     return studyDashboardResponse;
   }
 
+  @ApiOperation(value = "Get terms and policy details of application")
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 103, message = StudyMetaDataConstants.NO_RECORD),
+        @ApiResponse(code = 104, message = ErrorCodes.UNKNOWN),
+        @ApiResponse(
+            code = 200,
+            message = "Successful operation",
+            response = TermsPolicyResponse.class)
+      })
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
@@ -668,14 +796,26 @@ public class StudyMetaDataService {
     return termsPolicyResponse;
   }
 
+  @ApiOperation(value = "Get list of notifications of a particular app using appId")
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 102, message = StudyMetaDataConstants.INVALID_INPUT_ERROR_MSG),
+        @ApiResponse(code = 103, message = StudyMetaDataConstants.NO_RECORD),
+        @ApiResponse(code = 104, message = ErrorCodes.UNKNOWN),
+        @ApiResponse(
+            code = 200,
+            message = "Successful operation",
+            response = NotificationsResponse.class)
+      })
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
   @Path("notifications")
   public Object notifications(
-      @QueryParam("skip") String skip,
-      @HeaderParam("Authorization") String authorization,
-      @HeaderParam("applicationId") String appId,
+      @ApiParam(name = "skip", required = true) @QueryParam("skip") String skip,
+      @ApiParam(name = "Authorization", required = true) @HeaderParam("Authorization")
+          String authorization,
+      @ApiParam(name = "applicationId", required = true) @HeaderParam("applicationId") String appId,
       @Context ServletContext context,
       @Context HttpServletResponse response) {
     LOGGER.entry("begin notifications()");
@@ -712,13 +852,24 @@ public class StudyMetaDataService {
     return notificationsResponse;
   }
 
+  @ApiOperation(value = "Get latest app updates using app version")
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 102, message = StudyMetaDataConstants.INVALID_INPUT_ERROR_MSG),
+        @ApiResponse(code = 104, message = ErrorCodes.UNKNOWN),
+        @ApiResponse(
+            code = 200,
+            message = "Successful operation",
+            response = AppUpdatesResponse.class)
+      })
   @GET
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
   @Path("appUpdates")
   public Object appUpdates(
-      @QueryParam("appVersion") String appVersion,
-      @HeaderParam("Authorization") String authorization,
+      @ApiParam(name = "appVersion", required = true) @QueryParam("appVersion") String appVersion,
+      @ApiParam(name = "Authorization", required = true) @HeaderParam("Authorization")
+          String authorization,
       @Context ServletContext context,
       @Context HttpServletResponse response) {
     LOGGER.entry("begin appUpdates()");
@@ -748,13 +899,24 @@ public class StudyMetaDataService {
     return appUpdatesResponse;
   }
 
+  @ApiOperation(value = "Get latest study updates using study Id and study version")
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 102, message = StudyMetaDataConstants.INVALID_STUDY_ID),
+        @ApiResponse(code = 103, message = ErrorCodes.NO_DATA),
+        @ApiResponse(
+            code = 200,
+            message = "Successful operation",
+            response = StudyUpdatesResponse.class)
+      })
   @GET
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
   @Path("studyUpdates")
   public Object studyUpdates(
-      @QueryParam("studyId") String studyId,
-      @QueryParam("studyVersion") String studyVersion,
+      @ApiParam(name = "studyId", required = true) @QueryParam("studyId") String studyId,
+      @ApiParam(name = "studyVersion", required = true) @QueryParam("studyVersion")
+          String studyVersion,
       @Context ServletContext context,
       @Context HttpServletResponse response) {
     LOGGER.entry("begin studyUpdates()");
@@ -804,6 +966,13 @@ public class StudyMetaDataService {
     return studyUpdatesResponse;
   }
 
+  @ApiOperation(
+      value = "Update app version details like app version, OS type, custom study ID etc.")
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 102, message = StudyMetaDataConstants.INVALID_INPUT_ERROR_MSG),
+        @ApiResponse(code = 200, message = "Successful operation", response = String.class)
+      })
   @POST
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
@@ -884,12 +1053,21 @@ public class StudyMetaDataService {
     return updateAppVersionResponse;
   }
 
+  @ApiOperation(value = "This API will validate the Enrollment Token and return the response")
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 102, message = StudyMetaDataConstants.INVALID_INPUT_ERROR_MSG),
+        @ApiResponse(
+            code = 200,
+            message = "Successful operation",
+            response = EnrollmentTokenResponse.class)
+      })
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
   @Path("validateEnrollmentToken")
   public Object validateEnrollmentToken(
-      @QueryParam("token") String token,
+      @ApiParam(name = "token", required = true) @QueryParam("token") String token,
       @Context ServletContext context,
       @Context HttpServletResponse response) {
     LOGGER.entry("begin validateEnrollmentToken()");
@@ -932,18 +1110,31 @@ public class StudyMetaDataService {
     return enrollmentTokenResponse;
   }
 
+  @ApiOperation(
+      value = "Provides an indication about the health of the service",
+      notes = "Default response codes 400 and 401 are not applicable for this operation")
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 200, message = "Service is Up and Running"),
+      })
   @GET
   @Path("healthCheck")
   public String healthCheck() {
     return "200 OK!";
   }
 
+  @ApiOperation(value = "Get basic information of study using study Id")
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 102, message = StudyMetaDataConstants.INVALID_INPUT_ERROR_MSG),
+        @ApiResponse(code = 200, message = "Successful operation", response = StudyResponse.class)
+      })
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
   @Path("study")
   public Object study(
-      @QueryParam("studyId") String studyId,
+      @ApiParam(name = "studyId", required = true) @QueryParam("studyId") String studyId,
       @Context ServletContext context,
       @Context HttpServletResponse response) {
     LOGGER.entry("begin study()");
@@ -969,12 +1160,23 @@ public class StudyMetaDataService {
     return studyResponse;
   }
 
+  @ApiOperation(value = "Get the latest app (Android and IOS) version using application ID")
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 400, message = "Invalid resource"),
+        @ApiResponse(code = 404, message = "Details not found"),
+        @ApiResponse(
+            code = 200,
+            message = "Successful operation",
+            response = AppVersionInfoBean.class)
+      })
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
   @Path("versionInfo")
   public Object getAppVersionInfo(
-      @HeaderParam("applicationId") String appId, @Context HttpServletResponse response) {
+      @ApiParam(name = "applicationId", required = true) @HeaderParam("applicationId") String appId,
+      @Context HttpServletResponse response) {
     AppVersionInfoBean appVersionInfoBean = null;
     LOGGER.entry("begin getAppVersionInfo()");
 
@@ -1008,13 +1210,20 @@ public class StudyMetaDataService {
     return appVersionInfoBean;
   }
 
+  @ApiOperation(value = "This API will save the activities response")
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 400, message = "Invalid resource"),
+        @ApiResponse(code = 200, message = "Successful operation", response = String.class)
+      })
   @POST
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
   @Path("activityResponce")
   public Object storeJsonResponseFile(
       String params,
-      @HeaderParam("Authorization") String authorization,
+      @ApiParam(name = "Authorization", required = true) @HeaderParam("Authorization")
+          String authorization,
       @Context ServletContext context,
       @Context HttpServletResponse response)
       throws Exception {

--- a/study-datastore/src/main/java/com/hphc/mystudies/util/StudyMetaDataUtil.java
+++ b/study-datastore/src/main/java/com/hphc/mystudies/util/StudyMetaDataUtil.java
@@ -27,7 +27,6 @@ import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import com.hphc.mystudies.bean.FailureResponse;
-import com.sun.jersey.core.util.Base64;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -47,6 +46,7 @@ import java.util.concurrent.TimeUnit;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
+import org.glassfish.jersey.internal.util.Base64;
 import org.slf4j.ext.XLogger;
 import org.slf4j.ext.XLoggerFactory;
 
@@ -255,9 +255,9 @@ public class StudyMetaDataUtil {
     return "";
   }
 
-  public static String getDecodedStringByBase64(String encodedText) {
+  public static String getDecodedStringByBase64(byte[] encodedText) {
     LOGGER.entry("StudyMetaDataUtil: getDecodedStringByBase64() - Starts ");
-    if (StringUtils.isEmpty(encodedText)) {
+    if (StringUtils.isEmpty(encodedText.toString())) {
       return "";
     }
     try {
@@ -444,7 +444,8 @@ public class StudyMetaDataUtil {
     String platform = "";
     try {
       if (StringUtils.isNotEmpty(authCredentials) && authCredentials.contains("Basic")) {
-        final String encodedUserPassword = authCredentials.replaceFirst("Basic" + " ", "");
+        final byte[] encodedUserPassword =
+            authCredentials.replaceFirst("Basic" + " ", "").getBytes();
         byte[] decodedBytes = Base64.decode(encodedUserPassword);
         bundleIdAndAppToken = new String(decodedBytes, "UTF-8");
 
@@ -452,7 +453,6 @@ public class StudyMetaDataUtil {
           final StringTokenizer tokenizer = new StringTokenizer(bundleIdAndAppToken, ":");
           final String bundleId = tokenizer.nextToken();
           final String appToken = tokenizer.nextToken();
-
           if (authPropMap.containsValue(bundleId) && authPropMap.containsValue(appToken)) {
             String appBundleId = "";
             String appTokenId = "";
@@ -647,7 +647,8 @@ public class StudyMetaDataUtil {
     String appBundleId = "";
     try {
       if (StringUtils.isNotEmpty(authCredentials) && authCredentials.contains("Basic")) {
-        final String encodedUserPassword = authCredentials.replaceFirst("Basic" + " ", "");
+        final byte[] encodedUserPassword =
+            authCredentials.replaceFirst("Basic" + " ", "").getBytes();
         byte[] decodedBytes = Base64.decode(encodedUserPassword);
         bundleIdAndAppToken = new String(decodedBytes, "UTF-8");
         if (bundleIdAndAppToken.contains(":")) {

--- a/study-datastore/src/main/java/com/hphc/mystudies/web/servlet/AuthenticationService.java
+++ b/study-datastore/src/main/java/com/hphc/mystudies/web/servlet/AuthenticationService.java
@@ -21,15 +21,14 @@
  * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
  * OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.hphc.mystudies.web.servlet;
 
 import com.hphc.mystudies.util.StudyMetaDataUtil;
-import com.sun.jersey.core.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.StringTokenizer;
 import org.apache.commons.lang3.StringUtils;
+import org.glassfish.jersey.internal.util.Base64;
 import org.slf4j.ext.XLogger;
 import org.slf4j.ext.XLoggerFactory;
 
@@ -49,7 +48,8 @@ public class AuthenticationService {
     String appTokenKey = "";
     try {
       if (StringUtils.isNotEmpty(authCredentials) && authCredentials.contains("Basic")) {
-        final String encodedUserPassword = authCredentials.replaceFirst("Basic" + " ", "");
+        final byte[] encodedUserPassword =
+            authCredentials.replaceFirst("Basic" + " ", "").getBytes();
         byte[] decodedBytes = Base64.decode(encodedUserPassword);
         bundleIdAndAppToken = new String(decodedBytes, "UTF-8");
         if (bundleIdAndAppToken.contains(":")) {

--- a/study-datastore/src/main/resources/hibernate.cfg.xml
+++ b/study-datastore/src/main/resources/hibernate.cfg.xml
@@ -22,7 +22,8 @@
 		<property name="hibernate.cache.use_second_level_cache">false</property>
 		<property name="hibernate.cache.use_query_cache">false</property>
 		<property name="cache.provider_class">org.hibernate.cache.NoCacheProvider</property>
-
+		<property name="javax.persistence.validation.mode">none</property>
+		
 		<mapping class="com.hphc.mystudies.dto.BrandingDto" />
 		<mapping class="com.hphc.mystudies.dto.ChartsDto" />
 		<mapping class="com.hphc.mystudies.dto.ComprehensionTestQuestionDto" />

--- a/study-datastore/src/main/webapp/WEB-INF/web.xml
+++ b/study-datastore/src/main/webapp/WEB-INF/web.xml
@@ -14,17 +14,13 @@
 	</servlet>
 	<servlet>
 		<servlet-name>StudyMetaData REST Service</servlet-name>
-		<servlet-class>com.sun.jersey.spi.container.servlet.ServletContainer</servlet-class>
+		<servlet-class>org.glassfish.jersey.servlet.ServletContainer</servlet-class>
 		<init-param>
-			<param-name>com.sun.jersey.config.property.packages</param-name>
-			<param-value>com.hphc.mystudies.service,com.hphc.mystudies.dto,com.hphc.mystudies.corn,org.codehaus.jackson.jaxrs</param-value>
+			<param-name>jersey.config.server.provider.packages</param-name>
+			<param-value>io.swagger.jaxrs.json,io.swagger.jaxrs.listing,com.hphc.mystudies.service,com.hphc.mystudies.util,com.hphc.mystudies.dto,com.hphc.mystudies.corn,org.codehaus.jackson.jaxrs,com.hphc.mystudies.bean</param-value>
 		</init-param>
 		<init-param>
-			<param-name>com.sun.jersey.api.json.POJOMappingFeature</param-name>
-			<param-value>true</param-value>
-		</init-param>
-		<init-param>
-			<param-name>com.sun.jersey.config.feature.DisableWADL</param-name>
+			<param-name>jersey.config.server.wadl.disableWadl</param-name>
 			<param-value>true</param-value>
 		</init-param>
 		<load-on-startup>2</load-on-startup>
@@ -33,7 +29,7 @@
 		<servlet-name>StudyMetaData REST Service</servlet-name>
 		<url-pattern>/*</url-pattern>
 	</servlet-mapping>
-
+    
 	<!-- Force SSL for entire site -->
 	<security-constraint>
 		<web-resource-collection>


### PR DESCRIPTION
Issue #3125, API documentation using swagger - Study Datastore.

- JSON `documentation/API/study-datastore/swagger.json` file will be created at compile time which user can use in [swagger editor](https://editor.swagger.io/) to view the API documentation of study datastore.

- Added swagger dependencies and upgraded com.sun.jersey to org.glassfish.jersey.

- Added `com.github.kongchen` plugin to generate json file at run time.

- Created `QuestionnaireStepsBean.java` to overcome Jackson circular dependencies for List of Questionnaire steps







