### PR TITLE
Add db migration to address text case changes for response types

### DIFF
--- a/db-migration/study-builder-db-migration/db/migration/V2_0_6__release.sql
+++ b/db-migration/study-builder-db-migration/db/migration/V2_0_6__release.sql
@@ -1,0 +1,5 @@
+UPDATE fda_hphc.question_responsetype_master_info SET response_type = 'Continuous scale' WHERE response_type = 'Continuous Scale';
+UPDATE fda_hphc.question_responsetype_master_info SET response_type = 'Text scale' WHERE response_type = 'Text Scale';
+UPDATE fda_hphc.question_responsetype_master_info SET response_type = 'Value picker' WHERE response_type = 'Value Picker';
+UPDATE fda_hphc.question_responsetype_master_info SET response_type = 'Image choice' WHERE response_type = 'Image Choice';
+UPDATE fda_hphc.question_responsetype_master_info SET response_type = 'Text choice' WHERE response_type = 'Text Choice';


### PR DESCRIPTION
The updates to the version_info.sql script for initialisation of the fda_hphc schema were not added to a db migration, so updates to 2.0.5 from any lower version caused failures such as the one described in https://github.com/GoogleCloudPlatform/fda-mystudies/issues/3551

We have run this migration against our own deployment and it fixes the above issue