### PR TITLE
[v2.0.6] Fixed issue #3600 [SB] View mode of the study > Overview screen > User is able to edit the 'Description' field in view mode 

### DIFF
--- a/study-builder/fdahpStudyDesigner/src/main/webapp/WEB-INF/view/study/overViewPage.jsp
+++ b/study-builder/fdahpStudyDesigner/src/main/webapp/WEB-INF/view/study/overViewPage.jsp
@@ -461,6 +461,8 @@
             });
     
     <c:if test="${not empty permission}">
+    $(".note-editable").attr("contenteditable","false");
+    $(".note-toolbar").attr("class","disabled");
     $('.summernote').summernote('disable');
     </c:if>
     


### PR DESCRIPTION
[SB] View mode of the study > Overview screen > User is able to edit the 'Description' field in view mode #3600

Issue: User is able to edit the summernote editor when multiple editor is added in overview screen. 
Fix: Explicitly disabled all editors by updating `contenteditable` attribute to false, when checking the study in view mode.