### PR TITLE
[v2.0.6] Fixed issue #3606 [SB] Comprehension test > 'Minimum score needed to pass the test' field should be mandatory field

### DIFF
--- a/study-builder/fdahpStudyDesigner/src/main/webapp/WEB-INF/view/study/comprehensionList.jsp
+++ b/study-builder/fdahpStudyDesigner/src/main/webapp/WEB-INF/view/study/comprehensionList.jsp
@@ -158,10 +158,14 @@
       </div>
 
       <div class="right-content-body mt-xlg" id="displayTitleId">
-        <div class="gray-xs-f mb-xs" id="minScoreText">Minimum score needed to pass the test</div>
-        <div class="form-group col-md-5 p-none scoreClass">
+        <div class="gray-xs-f mb-xs" id="minScoreText">Minimum score needed to pass the test
+	      <span
+	        class="requiredStar">*
+	      </span>
+        </div>
+		<div class="form-group col-md-3 p-none scoreClass">
           <input type="text" id="comprehensionTestMinimumScore" class="form-control"
-                 name="comprehensionTestMinimumScore"
+                 name="comprehensionTestMinimumScore" data-error="Please fill out this field"
                  value="${consentBo.comprehensionTestMinimumScore}"
                  maxlength="3" onkeypress="return isNumber(event)"  Style="width:250px">
           <div class="help-block with-errors red-txt"></div>
@@ -208,6 +212,7 @@ var markAsComplete = "${markAsComplete}"
       if (val == "Yes") {
     	  $("#saveId").html("Next");	
           $("#comprehensionTestMinimumScore, #minScoreText").hide();	
+          $('#comprehensionTestMinimumScore').attr('required', true);
           $('#spanAddQaId').attr('data-original-title', 'Please click on Next to start adding questions');	
           $("#mainContainer").show();	
           if ($('#comprehension_list tbody tr').length == 1	
@@ -227,6 +232,7 @@ var markAsComplete = "${markAsComplete}"
         }
       } else {
     	$("#saveId").html("Save");
+    	$('#comprehensionTestMinimumScore').attr('required', false);
         $("#comprehensionTestMinimumScore").val('');
         $("#mainContainer").hide();
         $("#addHelpNote").hide();


### PR DESCRIPTION
[SB] Comprehension test > 'Minimum score needed to pass the test' field should be mandatory field #3606

Issue: 'Minimum score needed to pass the test' field; is not a mandatory field so the user is able to do 'Mark as completed' without entering that field

Fix: Added `required` attribute and `data-error="Please fill out this field"` with red star mark to denote this input is required field