### PR TITLE
[v2.0.6] - Fixed issue #3745

### DIFF
--- a/study-builder/fdahpStudyDesigner/src/main/webapp/WEB-INF/view/study/viewFetalStudyActiveTask.jsp
+++ b/study-builder/fdahpStudyDesigner/src/main/webapp/WEB-INF/view/study/viewFetalStudyActiveTask.jsp
@@ -1188,7 +1188,7 @@
             $(this).val(newVal);
             $(this).parent().addClass("has-danger has-error");
             $(this).parent().find(".help-block").empty().append($("<ul><li> </li></ul>").attr("class","list-unstyled").text(
-                "The characters like (< >) are not allowed"));
+                "Please use characters from the following set only: A-Z a-z 0-9 *()_+|:.-"));
           }
         }
       });

--- a/study-builder/fdahpStudyDesigner/src/main/webapp/js/common.js
+++ b/study-builder/fdahpStudyDesigner/src/main/webapp/js/common.js
@@ -221,7 +221,7 @@ $(document)
                             .empty()
                             .append($("<ul><li> </li></ul>")
                             .attr("class","list-unstyled")
-                            .text("The characters like (< >) are not allowed"));
+                            .text("Please use characters from the following set only: A-Z a-z 0-9 *()_+|:.-"));
                       }
                     }
                   });


### PR DESCRIPTION
Fixed issue #3745, by changing error message from `The characters like (< >) are not allowed` to `Please use characters from the following set only: A-Z a-z 0-9 *()_+|:.-`