### PR TITLE
[v2.0.6] Fixed issues #3797 #3741 study builder active tasks custom schedule 

### DIFF
--- a/db-migration/study-builder-db-migration/db/migration/V2_0_6__release.sql
+++ b/db-migration/study-builder-db-migration/db/migration/V2_0_6__release.sql
@@ -823,23 +823,34 @@ DELIMITER ;
 
 
 
-ALTER TABLE fda_hphc.active_task_custom_frequencies 
-RENAME COLUMN frequency_time TO frequency_end_time;
-
-ALTER TABLE fda_hphc.active_task_custom_frequencies
-  ADD frequency_start_time varchar(255) DEFAULT NULL
-  AFTER frequency_end_time;
+UPDATE fda_hphc.active_task_custom_frequencies SET frequency_start_time = frequency_time
+  WHERE frequency_time IS NOT NULL;
   
-UPDATE fda_hphc.active_task_custom_frequencies SET frequency_start_time = frequency_end_time
-  WHERE frequency_end_time IS NOT NULL;
+UPDATE fda_hphc.active_task_custom_frequencies SET frequency_end_time = frequency_time
+  WHERE frequency_time IS NOT NULL;
+
+ALTER TABLE fda_hphc.active_task_custom_frequencies  
+  MODIFY frequency_start_time varchar(255) AFTER frequency_end_date;
+
+ALTER TABLE fda_hphc.active_task_custom_frequencies  
+  MODIFY frequency_end_time varchar(255) AFTER frequency_start_time;
+
+ALTER TABLE fda_hphc.active_task_custom_frequencies  
+  DROP COLUMN frequency_time;
 
 
-ALTER TABLE fda_hphc.questionnaires_custom_frequencies 
-RENAME COLUMN frequency_time TO frequency_end_time;
 
-ALTER TABLE fda_hphc.questionnaires_custom_frequencies
-  ADD frequency_start_time varchar(255) DEFAULT NULL
-  AFTER frequency_end_time;
+UPDATE fda_hphc.questionnaires_custom_frequencies SET frequency_start_time = frequency_time
+  WHERE frequency_time IS NOT NULL;
 
-UPDATE fda_hphc.questionnaires_custom_frequencies SET frequency_start_time = frequency_end_time
-  WHERE frequency_end_time IS NOT NULL;
+UPDATE fda_hphc.questionnaires_custom_frequencies SET frequency_end_time = frequency_time
+  WHERE frequency_time IS NOT NULL;
+
+ALTER TABLE fda_hphc.questionnaires_custom_frequencies  
+MODIFY frequency_start_time varchar(255) AFTER frequency_end_date;
+
+ALTER TABLE fda_hphc.questionnaires_custom_frequencies  
+  MODIFY frequency_end_time varchar(255) AFTER frequency_start_time;
+
+ALTER TABLE fda_hphc.questionnaires_custom_frequencies  
+  DROP COLUMN frequency_time;

--- a/study-builder/fdahpStudyDesigner/src/main/webapp/WEB-INF/view/study/activeTaskScheduled.jsp
+++ b/study-builder/fdahpStudyDesigner/src/main/webapp/WEB-INF/view/study/activeTaskScheduled.jsp
@@ -1018,17 +1018,6 @@
               <span class='help-block with-errors red-txt'></span>
             </span>
             
-            
-            <span class="form-group  dis-inline vertical-align-middle pr-md">
-              <input id="customStartTime${customVar.index}" type="text" count='${customVar.index}'
-                     class="form-control clock startTime cusTime ${activeTaskCustomScheduleBo.used ?'cursor-none' : ''}"
-                     name="activeTaskCustomScheduleBo[${customVar.index}].frequencyStartTime"
-                     value="${activeTaskCustomScheduleBo.frequencyStartTime}" placeholder="Start time"
-                     onclick='timep(this.id);'
-                     required data-error="Please fill out this field"/>
-              <span class='help-block with-errors red-txt'></span>
-            </span>
-            
             <span class="form-group  dis-inline vertical-align-middle pr-md">
               <input id="customStartTime${customVar.index}" type="text" count='${customVar.index}'
                      class="form-control clock startTime cusTime ${activeTaskCustomScheduleBo.used ?'cursor-none' : ''}"

--- a/study-datastore/src/main/java/com/hphc/mystudies/dao/ActivityMetaDataDao.java
+++ b/study-datastore/src/main/java/com/hphc/mystudies/dao/ActivityMetaDataDao.java
@@ -2259,7 +2259,7 @@ public class ActivityMetaDataDao {
   public Map<String, Object> getQuestionaireQuestionFormatByType(
       QuestionsDto questionDto, String questionResultType, Session session, StudyDto studyDto)
       throws DAOException {
-	  LOGGER.entry("begin getQuestionaireQuestionFormatByType()");
+    LOGGER.entry("begin getQuestionaireQuestionFormatByType()");
     Map<String, Object> questionFormat = new LinkedHashMap<>();
     QuestionReponseTypeDto reponseType = null;
     try {
@@ -2356,7 +2356,7 @@ public class ActivityMetaDataDao {
 
   public Map<String, Object> formatQuestionScaleDetails(
       QuestionReponseTypeDto reponseType, StudyDto studyDto) throws DAOException {
-	  LOGGER.entry("begin formatQuestionScaleDetails()");
+    LOGGER.entry("begin formatQuestionScaleDetails()");
     Map<String, Object> questionFormat = new LinkedHashMap<>();
     try {
       questionFormat.put(
@@ -2438,7 +2438,7 @@ public class ActivityMetaDataDao {
 
   public Map<String, Object> formatQuestionContinuousScaleDetails(
       QuestionReponseTypeDto reponseType, StudyDto studyDto) throws DAOException {
-	  LOGGER.entry("begin formatQuestionContinuousScaleDetails()");
+    LOGGER.entry("begin formatQuestionContinuousScaleDetails()");
     Map<String, Object> questionFormat = new LinkedHashMap<>();
     try {
       questionFormat.put(
@@ -3000,25 +3000,19 @@ public class ActivityMetaDataDao {
             }
           }
 
-          if (StringUtils.isNotBlank(activeTaskFrequency.getFrequencyDate())) {
-            activityBean.setStartTime(
-                StudyMetaDataUtil.getFormattedDateTimeZone(
-                    startDateTime,
-                    StudyMetaDataConstants.SDF_DATE_TIME_PATTERN,
-                    StudyMetaDataConstants.SDF_DATE_TIME_TIMEZONE_MILLISECONDS_PATTERN));
-          }
+          activityBean.setStartTime(
+              StudyMetaDataUtil.getFormattedDateTimeZone(
+                  startDateTime,
+                  StudyMetaDataConstants.SDF_DATE_TIME_PATTERN,
+                  StudyMetaDataConstants.SDF_DATE_TIME_TIMEZONE_MILLISECONDS_PATTERN));
 
-          if (StringUtils.isNotBlank(activeTaskDto.getActiveTaskLifetimeEnd())) {
-            activityBean.setEndTime(
-                StringUtils.isEmpty(endDateTime)
-                    ? ""
-                    : StudyMetaDataUtil.getFormattedDateTimeZone(
-                        endDateTime,
-                        StudyMetaDataConstants.SDF_DATE_TIME_PATTERN,
-                        StudyMetaDataConstants.SDF_DATE_TIME_TIMEZONE_MILLISECONDS_PATTERN));
-          } else {
-            activityBean.setEndTime("");
-          }
+          activityBean.setEndTime(
+              StringUtils.isEmpty(endDateTime)
+                  ? ""
+                  : StudyMetaDataUtil.getFormattedDateTimeZone(
+                      endDateTime,
+                      StudyMetaDataConstants.SDF_DATE_TIME_PATTERN,
+                      StudyMetaDataConstants.SDF_DATE_TIME_TIMEZONE_MILLISECONDS_PATTERN));
 
           activityBean.setIsLaunchStudy(activeTaskFrequency.isLaunchStudy());
           activityBean.setIsStudyLifeTime(activeTaskFrequency.isStudyLifeTime());
@@ -3051,8 +3045,6 @@ public class ActivityMetaDataDao {
                     startDateTime,
                     StudyMetaDataConstants.SDF_DATE_TIME_PATTERN,
                     StudyMetaDataConstants.SDF_DATE_TIME_TIMEZONE_MILLISECONDS_PATTERN));
-          } else {
-            activityBean.setStartTime("");
           }
 
           if (null != activeTaskDto.getActiveTaskLifetimeEnd()) {
@@ -3061,8 +3053,6 @@ public class ActivityMetaDataDao {
                     endDateTime,
                     StudyMetaDataConstants.SDF_DATE_TIME_PATTERN,
                     StudyMetaDataConstants.SDF_DATE_TIME_TIMEZONE_MILLISECONDS_PATTERN));
-          } else {
-            activityBean.setEndTime("");
           }
 
         } else if (activeTaskDto
@@ -3138,8 +3128,6 @@ public class ActivityMetaDataDao {
                       endDateTime,
                       StudyMetaDataConstants.SDF_DATE_TIME_PATTERN,
                       StudyMetaDataConstants.SDF_DATE_TIME_TIMEZONE_MILLISECONDS_PATTERN));
-            } else {
-              activityBean.setEndTime("");
             }
           }
         }
@@ -4124,7 +4112,7 @@ public class ActivityMetaDataDao {
                 "^([0-9]|0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$")) {
               frequencyStartTime = frequencyStartTime + ":00";
             }
-            
+
             start.setTime(frequencyStartTime);
             end.setAnchorDays(
                 manuallyScheduleFrequencyList
@@ -4252,6 +4240,7 @@ public class ActivityMetaDataDao {
             manuallyScheduleFrequencyList) {
           ActivityFrequencyAnchorRunsBean activityFrequencyAnchorRunsBean =
               new ActivityFrequencyAnchorRunsBean();
+
           if (null != customFrequencyDto.getTimePeriodFromDays()) {
             activityFrequencyAnchorRunsBean.setStartDays(
                 customFrequencyDto.isxDaysSign()


### PR DESCRIPTION

- [SB] [QA] Active tasks custom schedule > Three time fields are showing for each custom schedule row and UI is distorted #3797

- [SB] Active tasks > Regular/Anchor based One Time> 'startTime' displaying empty for launch with study option and hence activities are not displaying in mobile apps #3741

