### PR TITLE
[v2.0.6] Fixed issue 3803

### DIFF
--- a/study-datastore/pom.xml
+++ b/study-datastore/pom.xml
@@ -246,10 +246,10 @@
       <artifactId>lombok</artifactId>
       <version>1.18.12</version>
     </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>2.6.2</version>
+	<dependency>
+	  <groupId>com.fasterxml.jackson.core</groupId>
+	  <artifactId>jackson-core</artifactId>
+	  <version>2.6.2</version>
     </dependency>
     <dependency>
 	  <groupId>com.fasterxml.jackson.core</groupId>

--- a/study-datastore/src/main/java/com/hphc/mystudies/dao/ActivityMetaDataDao.java
+++ b/study-datastore/src/main/java/com/hphc/mystudies/dao/ActivityMetaDataDao.java
@@ -3169,7 +3169,8 @@ public class ActivityMetaDataDao {
                   session
                       .createQuery(
                           "from QuestionnairesFrequenciesDto QFDTO"
-                              + " where QFDTO.questionnairesId=:quesRespId")
+                              + " where QFDTO.questionnairesId=:quesRespId"
+                              + " order by QFDTO.frequencyDate, QCFDTO.timePeriodFromDays")
                       .setString("quesRespId", questionaire.getId())
                       .uniqueResult();
           if ((questionnairesFrequency != null)

--- a/study-datastore/src/main/java/com/hphc/mystudies/dao/ActivityMetaDataDao.java
+++ b/study-datastore/src/main/java/com/hphc/mystudies/dao/ActivityMetaDataDao.java
@@ -4232,7 +4232,8 @@ public class ActivityMetaDataDao {
           session
               .createQuery(
                   "from QuestionnairesCustomFrequenciesDto QCFDTO"
-                      + " where QCFDTO.questionnairesId=:quesResId")
+                      + " where QCFDTO.questionnairesId=:quesResId"
+                      + " ORDER BY QCFDTO.frequencyStartDate ASC, QCFDTO.frequencyStartTime")
               .setString("quesResId", questionaire.getId())
               .list();
       if ((manuallyScheduleFrequencyList != null) && !manuallyScheduleFrequencyList.isEmpty()) {
@@ -4507,7 +4508,8 @@ public class ActivityMetaDataDao {
           session
               .createQuery(
                   "from ActiveTaskCustomFrequenciesDto QCFDTO"
-                      + " where QCFDTO.activeTaskId=:activeTaskId")
+                      + " where QCFDTO.activeTaskId=:activeTaskId"
+                      + " ORDER BY QCFDTO.frequencyStartDate ASC, QCFDTO.frequencyStartTime")
               .setString("activeTaskId", activeTaskDto.getId())
               .list();
       if ((manuallyScheduleFrequencyList != null) && !manuallyScheduleFrequencyList.isEmpty()) {

--- a/study-datastore/src/main/java/com/hphc/mystudies/dao/ActivityMetaDataDao.java
+++ b/study-datastore/src/main/java/com/hphc/mystudies/dao/ActivityMetaDataDao.java
@@ -3169,8 +3169,7 @@ public class ActivityMetaDataDao {
                   session
                       .createQuery(
                           "from QuestionnairesFrequenciesDto QFDTO"
-                              + " where QFDTO.questionnairesId=:quesRespId"
-                              + " order by QFDTO.frequencyDate, QCFDTO.timePeriodFromDays")
+                              + " where QFDTO.questionnairesId=:quesRespId")
                       .setString("quesRespId", questionaire.getId())
                       .uniqueResult();
           if ((questionnairesFrequency != null)

--- a/study-datastore/src/main/java/com/hphc/mystudies/dao/ActivityMetaDataDao.java
+++ b/study-datastore/src/main/java/com/hphc/mystudies/dao/ActivityMetaDataDao.java
@@ -4097,7 +4097,7 @@ public class ActivityMetaDataDao {
                   .createQuery(
                       "from ActiveTaskCustomFrequenciesDto QCFDTO"
                           + " where QCFDTO.activeTaskId=:activeTaskId"
-                          + " order by QCFDTO.id")
+                          + " order by QCFDTO.frequencyStartDate, QCFDTO.timePeriodFromDays")
                   .setString("activeTaskId", activeTaskDto.getId())
                   .list();
           if ((manuallyScheduleFrequencyList != null) && !manuallyScheduleFrequencyList.isEmpty()) {
@@ -4142,7 +4142,7 @@ public class ActivityMetaDataDao {
                   .createQuery(
                       "from ActiveTaskFrequencyDto QCFDTO"
                           + " where QCFDTO.activeTaskId=:activeTaskId"
-                          + " order by QCFDTO.id")
+                          + " order by QCFDTO.frequencyDate, QCFDTO.timePeriodFromDays")
                   .setString("activeTaskId", activeTaskDto.getId())
                   .list();
 
@@ -4164,7 +4164,8 @@ public class ActivityMetaDataDao {
                   session
                       .createQuery(
                           "from ActiveTaskFrequencyDto QFDTO"
-                              + " where QFDTO.activeTaskId=:activeTaskId")
+                              + " where QFDTO.activeTaskId=:activeTaskId"
+                              + " order by QFDTO.frequencyDate, QFDTO.timePeriodFromDays")
                       .setString("activeTaskId", activeTaskDto.getId())
                       .uniqueResult();
           if (taskFrequencyDto != null) {
@@ -4372,7 +4373,7 @@ public class ActivityMetaDataDao {
                   .createQuery(
                       "from QuestionnairesCustomFrequenciesDto QCFDTO"
                           + " where QCFDTO.questionnairesId=:questId"
-                          + " order by QCFDTO.id")
+                          + " order by QCFDTO.frequencyStartDate, QCFDTO.timePeriodFromDays")
                   .setString("questId", questionaire.getId())
                   .list();
           if ((manuallyScheduleFrequencyList != null) && !manuallyScheduleFrequencyList.isEmpty()) {
@@ -4418,7 +4419,7 @@ public class ActivityMetaDataDao {
                   .createQuery(
                       "from QuestionnairesFrequenciesDto QCFDTO"
                           + " where QCFDTO.questionnairesId=:questId"
-                          + " order by QCFDTO.id")
+                          + " order by QCFDTO.frequencyDate, QCFDTO.timePeriodFromDays")
                   .setString("questId", questionaire.getId())
                   .list();
 
@@ -4443,7 +4444,8 @@ public class ActivityMetaDataDao {
                   session
                       .createQuery(
                           "from QuestionnairesFrequenciesDto QFDTO"
-                              + " where QFDTO.questionnairesId=:questId")
+                              + " where QFDTO.questionnairesId=:questId"
+                              + " order by QFDTO.frequencyDate, QFDTO.timePeriodFromDays")
                       .setString("questId", questionaire.getId())
                       .uniqueResult();
           if (questionnairesFrequency != null) {


### PR DESCRIPTION
[SB] [Import] Custom schedule > Order of the runs is incorrect in GetStudyActivityList API for imported study hence scheduling in mobile apps is incorrect #3803

Issue :Actual: Order of the runs is incorrect which is causing mobile apps scheduling behave indifferently for imported study
Expected: Order should be same as of original study