### PR TITLE
[v2.0.6] Fixed issue #3824 #3828

### DIFF
--- a/study-builder/fdahpStudyDesigner/src/main/webapp/WEB-INF/templates/subheader.jsp
+++ b/study-builder/fdahpStudyDesigner/src/main/webapp/WEB-INF/templates/subheader.jsp
@@ -126,7 +126,11 @@
 		          },
 		        },
 		    callback: function (result) {
-		    	var decodedURL = decodeURIComponent(result);
+		    	if(result == null){
+		    		return;
+		    	}
+		    	
+		    	var decodedURL = unescape(result);
 		    	var storagePath = "${sessionObject.storagePath}";
 		    	if(decodedURL !=null && !(decodedURL.startsWith(storagePath) && decodedURL.includes("Expires="))){
 		    		showErrMsg("Please enter a valid URL");


### PR DESCRIPTION
#3824: Added return statement to break the function when URL is null.
#3828: Added unescape() instead decodeURIComponent() to fix this issue