### PR TITLE
[v2.0.6] Fixed #3173 study builder for the admin to change password

### DIFF
--- a/deployment/scripts/create_study_builder_superadmin.sh
+++ b/deployment/scripts/create_study_builder_superadmin.sh
@@ -42,9 +42,9 @@ ACCESS_CODE=`cat /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | fold -w 6 | head -n 1
 # e.g. 2018-01-18 14:36:41
 DATETIME=`date +"%F %T"`
 if [[ "$OSTYPE" == "darwin"* ]]; then
-EXPIRY_DATETIME=`date -v -90d +"%F %T"`
+EXPIRY_DATETIME=`date -v -91d +"%F %T"`
 else # linux
-EXPIRY_DATETIME=`date -d -90days +"%F %T"`
+EXPIRY_DATETIME=`date -d -91days +"%F %T"`
 fi
 
 echo "DELETE FROM user_permission_mapping WHERE user_id=1;" >> ${TMPFILE}


### PR DESCRIPTION
Fixed issue :
When logged in with default superadmin credentials should force the admin to change password #3173
added one day extra in EXPIRY_DATETIME, to avoid issues related to time zone difference.
 