### PR TITLE
[v2.0.8] Fixed issue #4012 study builder Active task custom scheduling GetStudyActivityList API 

### DIFF
--- a/study-datastore/src/main/java/com/hphc/mystudies/dao/ActivityMetaDataDao.java
+++ b/study-datastore/src/main/java/com/hphc/mystudies/dao/ActivityMetaDataDao.java
@@ -1163,11 +1163,7 @@ public class ActivityMetaDataDao {
               .createQuery(
                   "from ActiveTaskCustomFrequenciesDto ATCFDTO"
                       + " where ATCFDTO.activeTaskId=:activeTaskId"
-                      + " ORDER BY"
-                      + " case ATCFDTO.xDaysSign when '1' then ATCFDTO.timePeriodFromDays END DESC,"
-                      + " case ATCFDTO.xDaysSign when '1' then ATCFDTO.frequencyStartTime END ASC,"
-                      + " case ATCFDTO.xDaysSign when '0' then ATCFDTO.timePeriodFromDays END ASC,"
-                      + " case ATCFDTO.xDaysSign when '0' then ATCFDTO.frequencyStartTime END ASC")
+                      + " ORDER BY ATCFDTO.frequencyStartDate ASC, ATCFDTO.frequencyStartTime")
               .setString("activeTaskId", activeTask.getId())
               .list();
       if ((manuallyScheduleFrequencyList != null) && !manuallyScheduleFrequencyList.isEmpty()) {
@@ -3001,13 +2997,15 @@ public class ActivityMetaDataDao {
           }
 
           activityBean.setStartTime(
-              StudyMetaDataUtil.getFormattedDateTimeZone(
-                  startDateTime,
-                  StudyMetaDataConstants.SDF_DATE_TIME_PATTERN,
-                  StudyMetaDataConstants.SDF_DATE_TIME_TIMEZONE_MILLISECONDS_PATTERN));
+              StringUtils.isEmpty(activeTaskDto.getActiveTaskLifetimeStart())
+                  ? ""
+                  : StudyMetaDataUtil.getFormattedDateTimeZone(
+                      startDateTime,
+                      StudyMetaDataConstants.SDF_DATE_TIME_PATTERN,
+                      StudyMetaDataConstants.SDF_DATE_TIME_TIMEZONE_MILLISECONDS_PATTERN));
 
           activityBean.setEndTime(
-              StringUtils.isEmpty(endDateTime)
+              StringUtils.isEmpty(activeTaskDto.getActiveTaskLifetimeEnd())
                   ? ""
                   : StudyMetaDataUtil.getFormattedDateTimeZone(
                       endDateTime,


### PR DESCRIPTION
Fixed issue
[SB] Active task custom scheduling > Order of runs is incorrect in GetStudyActivityList API in a scenario #4012