### PR TITLE
[v2.0.9] Apache Log4j Security Vulnerabilities issue fix (master)

### DIFF
--- a/documentation/whats-new.md
+++ b/documentation/whats-new.md
@@ -6,6 +6,9 @@
 -->
 
 > Subscribe to [mystudies-announce@googlegroups.com](https://groups.google.com/g/mystudies-announce/) to receive release notifications and announcements
+# Release 2.0.9
+* This release fixes the security vulnerability detected with Log4j recently.  More information on the vulnerability is here (https://logging.apache.org/log4j/2.x/security.html#CVE-2021-45046). 
+* Note: The platform was using a Log4j version which is not impacted by this vulnerability. However, as a safety measure, the platform is now updated with this release, to use the latest Log4j version 2.16.0 provided by Apache to address this vulnerability.
 
 # Release 2.0.8
 * Note: This release requires users to update to new versions of the mobile apps from the app stores.

--- a/documentation/whats-new.md
+++ b/documentation/whats-new.md
@@ -7,8 +7,8 @@
 
 > Subscribe to [mystudies-announce@googlegroups.com](https://groups.google.com/g/mystudies-announce/) to receive release notifications and announcements
 # Release 2.0.9
-* This release fixes the security vulnerability detected with Log4j recently.  More information on the vulnerability is here (https://logging.apache.org/log4j/2.x/security.html#CVE-2021-45046). 
-* Note: The platform was using a Log4j version which is not impacted by this vulnerability. However, as a safety measure, the platform is now updated with this release, to use the latest Log4j version 2.16.0 provided by Apache to address this vulnerability.
+* This release fixes the security vulnerability detected with Log4j recently. More information on the vulnerability is here (https://logging.apache.org/log4j/2.x/security.html#CVE-2021-45046). 
+* Note: The platform was using a log4j version and logging framework which is not impacted by this vulnerability. However, as a safety measure, the platform is updated with release v2.0.9, to use the latest Log4j version 2.16.0 that was provided by Apache to address this issue.
 
 # Release 2.0.8
 * Note: This release requires users to update to new versions of the mobile apps from the app stores.

--- a/participant-datastore/consent-mgmt-module/consent-mgmt/pom.xml
+++ b/participant-datastore/consent-mgmt-module/consent-mgmt/pom.xml
@@ -66,11 +66,26 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-log4j2</artifactId>
-    </dependency>
-    <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core -->
+   <dependency>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-log4j2</artifactId>
+		<exclusions>
+			<exclusion>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-core</artifactId>
+			</exclusion>
+		</exclusions>
+	</dependency>
+	<dependency>
+		<groupId>org.apache.logging.log4j</groupId>
+		<artifactId>log4j-core</artifactId>
+		<version>2.16.0</version>
+	</dependency>
+	<dependency>
+		<groupId>org.apache.logging.log4j</groupId>
+		<artifactId>log4j-api</artifactId>
+		<version>2.16.0</version>
+	</dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-devtools</artifactId>

--- a/participant-datastore/consent-mgmt-module/consent-mgmt/pom.xml
+++ b/participant-datastore/consent-mgmt-module/consent-mgmt/pom.xml
@@ -66,7 +66,7 @@
         </exclusion>
       </exclusions>
     </dependency>
-   <dependency>
+	<dependency>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-log4j2</artifactId>
 		<exclusions>

--- a/participant-datastore/enroll-mgmt-module/enroll-mgmt/pom.xml
+++ b/participant-datastore/enroll-mgmt-module/enroll-mgmt/pom.xml
@@ -42,10 +42,26 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>
     </dependency>
-     <dependency>
-    <groupId>org.springframework.boot</groupId>
-    <artifactId>spring-boot-starter-log4j2</artifactId>
-   </dependency> 
+	<dependency>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-log4j2</artifactId>
+		<exclusions>
+			<exclusion>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-core</artifactId>
+			</exclusion>
+		</exclusions>
+	</dependency>
+	<dependency>
+		<groupId>org.apache.logging.log4j</groupId>
+		<artifactId>log4j-core</artifactId>
+		<version>2.16.0</version>
+	</dependency>
+	<dependency>
+		<groupId>org.apache.logging.log4j</groupId>
+		<artifactId>log4j-api</artifactId>
+		<version>2.16.0</version>
+	</dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-jdbc</artifactId>

--- a/participant-datastore/user-mgmt-module/user-mgmt/pom.xml
+++ b/participant-datastore/user-mgmt-module/user-mgmt/pom.xml
@@ -64,16 +64,16 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-log4j2</artifactId>
-      <exclusions>
+	<dependency>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-log4j2</artifactId>
+		<exclusions>
 			<exclusion>
 				<groupId>org.apache.logging.log4j</groupId>
 				<artifactId>log4j-core</artifactId>
 			</exclusion>
-	  </exclusions>
-    </dependency>
+		</exclusions>
+	</dependency>
 	<dependency>
 		<groupId>org.apache.logging.log4j</groupId>
 		<artifactId>log4j-core</artifactId>

--- a/participant-datastore/user-mgmt-module/user-mgmt/pom.xml
+++ b/participant-datastore/user-mgmt-module/user-mgmt/pom.xml
@@ -67,7 +67,23 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-log4j2</artifactId>
+      <exclusions>
+			<exclusion>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-core</artifactId>
+			</exclusion>
+	  </exclusions>
     </dependency>
+	<dependency>
+		<groupId>org.apache.logging.log4j</groupId>
+		<artifactId>log4j-core</artifactId>
+		<version>2.16.0</version>
+	</dependency>
+	<dependency>
+		<groupId>org.apache.logging.log4j</groupId>
+		<artifactId>log4j-api</artifactId>
+		<version>2.16.0</version>
+	</dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-devtools</artifactId>
@@ -83,10 +99,6 @@
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
       <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-ext</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/study-builder/fdahpStudyDesigner/pom.xml
+++ b/study-builder/fdahpStudyDesigner/pom.xml
@@ -198,25 +198,6 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.sun.jmx</groupId>
-          <artifactId>jmxri</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.sun.jdmk</groupId>
-          <artifactId>jmxtools</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>javax.jms</groupId>
-          <artifactId>jms</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>jstl</artifactId>
       <version>1.2</version>

--- a/study-builder/fdahpStudyDesigner/src/main/resources/application.properties
+++ b/study-builder/fdahpStudyDesigner/src/main/resources/application.properties
@@ -58,7 +58,7 @@ security.oauth2.client.client-secret=${SECRET_KEY}
 
 # application version
 applicationVersion=1.0
-release.version=2.0.8
+release.version=2.0.9
 
 security.oauth2.token_endpoint=${SCIM_AUTH_URL}/oauth2/token
 security.oauth2.client.redirect-uri=${SCIM_AUTH_URL}/callback

--- a/study-datastore/pom.xml
+++ b/study-datastore/pom.xml
@@ -208,25 +208,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.sun.jmx</groupId>
-          <artifactId>jmxri</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.sun.jdmk</groupId>
-          <artifactId>jmxtools</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>javax.jms</groupId>
-          <artifactId>jms</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.quartz-scheduler</groupId>
       <artifactId>quartz</artifactId>
       <version>2.3.2</version>


### PR DESCRIPTION
This PR has the fix to address CVE-2021-44228 in Apache Log4j 2.16.0. For details please refer this issue #4302 